### PR TITLE
Fix incorrect path for policy requests

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -327,7 +327,7 @@ type Policies struct {
 func (c *Client) GetPolicy(ctx context.Context, id string) (*Policy, error) {
 	policyresponse := Policies{}
 
-	req, err := c.newRequest("GET", fmt.Sprintf("keys/%s/policy", id), nil)
+	req, err := c.newRequest("GET", fmt.Sprintf("keys/%s/policies", id), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -358,7 +358,7 @@ func (c *Client) SetPolicy(ctx context.Context, id string, prefer PreferReturn, 
 
 	policyresponse := Policies{}
 
-	req, err := c.newRequest("PUT", fmt.Sprintf("keys/%s/policy", id), &policyRequest)
+	req, err := c.newRequest("PUT", fmt.Sprintf("keys/%s/policies", id), &policyRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/kp_test.go
+++ b/kp_test.go
@@ -797,7 +797,7 @@ func TestPolicies(t *testing.T) {
 			"Policy Replace",
 			func(t *testing.T, api *API, ctx context.Context) error {
 				MockAuthURL(keyURL, http.StatusOK, testKeys)
-				MockAuthURL("/api/v2/keys/"+testKey+"/policy", http.StatusOK, testKeys)
+				MockAuthURL("/api/v2/keys/"+testKey+"/policies", http.StatusOK, testKeys)
 
 				_, err := api.SetPolicy(ctx, testKey, ReturnMinimal, 3)
 				assert.NoError(t, err)
@@ -812,7 +812,7 @@ func TestPolicies(t *testing.T) {
 			"Policy Get",
 			func(t *testing.T, api *API, ctx context.Context) error {
 				MockAuthURL(keyURL, http.StatusOK, testKeys)
-				MockAuthURL("/api/v2/keys/"+testKey+"/policy", http.StatusOK, testKeys)
+				MockAuthURL("/api/v2/keys/"+testKey+"/policies", http.StatusOK, testKeys)
 
 				_, err := api.GetPolicy(ctx, testKey)
 				assert.NoError(t, err)


### PR DESCRIPTION
GetPolicy and SetPolicy were making requests to `/policy`, which resulted in 501s 
- fix the paths to be `/policies`
- also change the paths in tests for consistency