### PR TITLE
Restore key

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -272,6 +272,8 @@ func (c *Client) RestoreKey(ctx context.Context, id, payload, encryptedNonce, iv
 
 	keysResponse := Keys{}
 
+	req.Header.Set("Prefer", preferHeaders[prefer])
+
 	if _, err := c.do(ctx, req, &keysResponse); err != nil {
 		return nil, err
 	}

--- a/keys.go
+++ b/keys.go
@@ -240,7 +240,7 @@ func (c *Client) DeleteKey(ctx context.Context, id string, prefer PreferReturn, 
 }
 
 // RestoreKey restores a deleted imported root key by specifying the ID of the key
-func (c *Client) RestoreKey(ctx context.Context, id, payload, encryptedNonce, iv string, prefer PreferReturn) (*Key, error) {
+func (c *Client) RestoreKey(ctx context.Context, id, payload, encryptedNonce, iv string) (*Key, error) {
 
 	if payload == "" {
 		return nil, fmt.Errorf("Please provide payload to restore the key")
@@ -271,8 +271,6 @@ func (c *Client) RestoreKey(ctx context.Context, id, payload, encryptedNonce, iv
 	req.URL.RawQuery = v.Encode()
 
 	keysResponse := Keys{}
-
-	req.Header.Set("Prefer", preferHeaders[prefer])
 
 	if _, err := c.do(ctx, req, &keysResponse); err != nil {
 		return nil, err

--- a/keys.go
+++ b/keys.go
@@ -239,6 +239,46 @@ func (c *Client) DeleteKey(ctx context.Context, id string, prefer PreferReturn, 
 	return nil, nil
 }
 
+// RestoreKey restores a deleted imported root key by specifying the ID of the key
+func (c *Client) RestoreKey(ctx context.Context, id, payload, encryptedNonce, iv string, prefer PreferReturn) (*Key, error) {
+
+	if payload == "" {
+		return nil, fmt.Errorf("Please provide payload to restore the key")
+	}
+
+	key := Key{
+		Payload:        payload,
+		IV:             iv,
+		EncryptedNonce: encryptedNonce,
+	}
+
+	keysRequest := Keys{
+		Metadata: KeysMetadata{
+			CollectionType: keyType,
+			NumberOfKeys:   1,
+		},
+		Keys: []Key{key},
+	}
+
+	v := url.Values{}
+	v.Set("action", "restore")
+
+	req, err := c.newRequest("POST", fmt.Sprintf("keys/%s", id), &keysRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	req.URL.RawQuery = v.Encode()
+
+	keysResponse := Keys{}
+
+	if _, err := c.do(ctx, req, &keysResponse); err != nil {
+		return nil, err
+	}
+
+	return &keysResponse.Keys[0], nil
+}
+
 // Wrap calls the wrap action with the given plain text.
 func (c *Client) Wrap(ctx context.Context, id string, plainText []byte, additionalAuthData *[]string) ([]byte, error) {
 	_, ct, err := c.wrap(ctx, id, plainText, additionalAuthData)

--- a/kp_test.go
+++ b/kp_test.go
@@ -777,11 +777,6 @@ func TestKeys(t *testing.T) {
 				kr, err := api.RestoreKey(ctx, key1, "JaokkJZffuuMOOC4YhuFspe8508ixeKvqskKhFw1f+w=", "", "", ReturnRepresentation)
 				assert.NoError(t, err)
 				assert.Equal(t, kr.State, 1)
-
-				MockAuthURL(keyURL, http.StatusServiceUnavailable, "{}")
-				_, err = api.RestoreKey(ctx, testKey, "JaokkJZffuuMOOC4YhuFspe8508ixeKvqskKhFw1f+w=", "", "", ReturnMinimal)
-				assert.Error(t, err)
-				return nil
 			},
 		},
 		{

--- a/kp_test.go
+++ b/kp_test.go
@@ -1492,7 +1492,7 @@ func TestRestoreKey(t *testing.T) {
 		]
 	}`)
 
-	gock.New("http://example.com").Reply(200).Body(bytes.NewReader(restoreKeyResponse))
+	gock.New("http://example.com").Reply(201).Body(bytes.NewReader(restoreKeyResponse))
 
 	c, _, err := NewTestClient(t, nil)
 	gock.InterceptClient(&c.HttpClient)

--- a/kp_test.go
+++ b/kp_test.go
@@ -774,9 +774,11 @@ func TestKeys(t *testing.T) {
 				assert.Equal(t, kd.State, 5)
 
 				MockAuthURL(keyURL, http.StatusOK, testRestoredKey)
-				kr, err := api.RestoreKey(ctx, key1, "JaokkJZffuuMOOC4YhuFspe8508ixeKvqskKhFw1f+w=", "", "", ReturnRepresentation)
+				kr, err := api.RestoreKey(ctx, key1, "JaokkJZffuuMOOC4YhuFspe8508ixeKvqskKhFw1f+w=", "", "")
 				assert.NoError(t, err)
 				assert.Equal(t, kr.State, 1)
+
+				return nil
 			},
 		},
 		{


### PR DESCRIPTION
Associated with the issue :KEYP-4957
Changes included in the PR: Added restore key functionality to the go sdk.