### PR TITLE
Add Registration methods to go sdk

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -41,24 +41,25 @@ type PreferReturn int
 
 // Key represents a key as returned by the KP API.
 type Key struct {
-	ID                  string     `json:"id,omitempty"`
-	Name                string     `json:"name,omitempty"`
-	Description         string     `json:"description,omitempty"`
-	Type                string     `json:"type,omitempty"`
-	Tags                []string   `json:"Tags,omitempty"`
-	AlgorithmType       string     `json:"algorithmType,omitempty"`
-	CreatedBy           string     `json:"createdBy,omitempty"`
-	CreationDate        *time.Time `json:"creationDate,omitempty"`
-	LastUpdateDate      *time.Time `json:"lastUpdateDate,omitempty"`
-	LastRotateDate      *time.Time `json:"lastRotateDate,omitempty"`
-	Extractable         bool       `json:"extractable"`
-	Expiration          *time.Time `json:"expirationDate,omitempty"`
-	Payload             string     `json:"payload,omitempty"`
-	State               int        `json:"state,omitempty"`
-	EncryptionAlgorithm string     `json:"encryptionAlgorithm,omitempty"`
-	CRN                 string     `json:"crn,omitempty"`
-	EncryptedNonce      string     `json:"encryptedNonce,omitempty"`
-	IV                  string     `json:"iv,omitempty"`
+	ID                  string      `json:"id,omitempty"`
+	Name                string      `json:"name,omitempty"`
+	Description         string      `json:"description,omitempty"`
+	Type                string      `json:"type,omitempty"`
+	Tags                []string    `json:"Tags,omitempty"`
+	AlgorithmType       string      `json:"algorithmType,omitempty"`
+	CreatedBy           string      `json:"createdBy,omitempty"`
+	CreationDate        *time.Time  `json:"creationDate,omitempty"`
+	LastUpdateDate      *time.Time  `json:"lastUpdateDate,omitempty"`
+	LastRotateDate      *time.Time  `json:"lastRotateDate,omitempty"`
+	KeyVersion          *KeyVersion `json:"keyVersion,omitempty" mapstructure:keyVersion`
+	Extractable         bool        `json:"extractable"`
+	Expiration          *time.Time  `json:"expirationDate,omitempty"`
+	Payload             string      `json:"payload,omitempty"`
+	State               int         `json:"state,omitempty"`
+	EncryptionAlgorithm string      `json:"encryptionAlgorithm,omitempty"`
+	CRN                 string      `json:"crn,omitempty"`
+	EncryptedNonce      string      `json:"encryptedNonce,omitempty"`
+	IV                  string      `json:"iv,omitempty"`
 }
 
 // KeysMetadata represents the metadata of a collection of keys.
@@ -80,6 +81,11 @@ type KeysActionRequest struct {
 	AAD        []string `json:"aad,omitempty"`
 	CipherText string   `json:"ciphertext,omitempty"`
 	Payload    string   `json:"payload,omitempty"`
+}
+
+type KeyVersion struct {
+	ID           string     `json:"id,omitempty"`
+	CreationDate *time.Time `json:"creationDate,omitempty"`
 }
 
 // CreateKey creates a new KP key.

--- a/kp_test.go
+++ b/kp_test.go
@@ -1293,3 +1293,176 @@ func TestDeleteKey_ForceOptTrue_URLHasForce(t *testing.T) {
 
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
 }
+
+func TestRegistrationsList(t *testing.T) {
+	defer gock.Off()
+	testKey := ""
+	testCRN := ""
+	allRegsResponse := []byte(`{
+		"metadata": {
+		  "collectionType": "application/vnd.ibm.kms.registration+json",
+		  "collectionTotal": 3
+		},
+		"resources": [
+		  {
+			"keyId": "3c44b-f03e6-4y9a5-b859b",
+			"resourceCrn": "crn:v1:dummy-env:dummy-service:global:a/dummy-details5:dummy-bucket3:dummy-reg2",
+			"creationDate": "2020-04-23T17:17:18Z",
+			"lastUpdated": "2020-04-23T17:17:18Z",
+			"keyVersion": {
+			  "id": "3c44b-f03e6-4y9a5-b859b",
+			  "creationDate": "2020-03-31T16:34:43Z"
+			}
+		  },
+		  {
+			"keyId": "3c44b-f03e6-4y9a5-b859b",
+			"resourceCrn": "crn:v1:dummy-ennv:dummy-service:global:a/dummy-details:dummy-bucket:dummy-reg",
+			"creationDate": "2020-04-23T17:17:58Z",
+			"lastUpdated": "2020-04-23T17:17:58Z",
+			"keyVersion": {
+			  "id": "3c44b-f03e6-4y9a5-b859b",
+			  "creationDate": "2020-03-31T16:34:43Z"
+			}
+		  },
+		  {
+			"keyId": "2n4y2-4ko2n-4m23f-23j3r",
+			"resourceCrn": "crn:v1:dummy-ennv:dummy-service:global:a/dummy-details:dummy-bucket:dummy-reg",
+			"creationDate": "2020-03-31T16:37:05Z",
+			"lastUpdated": "2020-03-31T16:37:05Z",
+			"keyVersion": {
+			  "id": "2n4y2-4ko2n-4m23f-23j3r",
+			  "creationDate": "2020-03-31T16:17:39Z"
+			}
+		  }
+		]
+	  }`)
+
+	RegsOfKeyResponse := []byte(`{
+		"metadata": {
+		  "collectionType": "application/vnd.ibm.kms.registration+json",
+		  "collectionTotal": 2
+		},
+		"resources": [
+		  {
+			"keyId": "3c44b-f03e6-4y9a5-b859b",
+			"resourceCrn": "crn:v1:dummy-env:dummy-service:global:a/dummy-details5:dummy-bucket3:dummy-reg2",
+			"creationDate": "2020-04-23T17:17:18Z",
+			"lastUpdated": "2020-04-23T17:17:18Z",
+			"keyVersion": {
+			  "id": "3c44b-f03e6-4y9a5-b859b",
+			  "creationDate": "2020-03-31T16:34:43Z"
+			}
+		  },
+		  {
+			"keyId": "3c44b-f03e6-4y9a5-b859b",
+			"resourceCrn": "crn:v1:dummy-ennv:dummy-service:global:a/dummy-details:dummy-bucket:dummy-reg",
+			"creationDate": "2020-04-23T17:17:58Z",
+			"lastUpdated": "2020-04-23T17:17:58Z",
+			"keyVersion": {
+			  "id": "3c44b-f03e6-4y9a5-b859b",
+			  "creationDate": "2020-03-31T16:34:43Z"
+			}
+		  }
+		]
+	  }`)
+
+	RegsOfCRNResponse := []byte(`{
+		"metadata": {
+		  "collectionType": "application/vnd.ibm.kms.registration+json",
+		  "collectionTotal": 2
+		},
+		"resources": [
+		  {
+			"keyId": "3c44b-f03e6-4y9a5-b859b",
+			"resourceCrn": "crn:v1:dummy-ennv:dummy-service:global:a/dummy-details:dummy-bucket:dummy-reg",
+			"creationDate": "2020-04-23T17:17:58Z",
+			"lastUpdated": "2020-04-23T17:17:58Z",
+			"keyVersion": {
+			  "id": "3c44b-f03e6-4y9a5-b859b",
+			  "creationDate": "2020-03-31T16:34:43Z"
+			}
+		  },
+		  {
+			"keyId": "2n4y2-4ko2n-4m23f-23j3r",
+			"resourceCrn": "crn:v1:dummy-ennv:dummy-service:global:a/dummy-details:dummy-bucket:dummy-reg",
+			"creationDate": "2020-03-31T16:37:05Z",
+			"lastUpdated": "2020-03-31T16:37:05Z",
+			"keyVersion": {
+			  "id": "2n4y2-4ko2n-4m23f-23j3r",
+			  "creationDate": "2020-03-31T16:17:39Z"
+			}
+		  }
+		]
+	  }`)
+
+	RegsOfKeyAndCRNResponse := []byte(`{
+		"metadata": {
+		  "collectionType": "application/vnd.ibm.kms.registration+json",
+		  "collectionTotal": 1
+		},
+		"resources": [
+		  {
+			"keyId": "2n4y2-4ko2n-4m23f-23j3r",
+			"resourceCrn": "crn:v1:dummy-ennv:dummy-service:global:a/dummy-details:dummy-bucket:dummy-reg",
+			"creationDate": "2020-03-31T16:37:05Z",
+			"lastUpdated": "2020-03-31T16:37:05Z",
+			"keyVersion": {
+			  "id": "2n4y2-4ko2n-4m23f-23j3r",
+			  "creationDate": "2020-03-31T16:17:39Z"
+			}
+		  }
+		]
+	  }`)
+
+	gock.New("http://example.com").Reply(200).Body(bytes.NewReader(allRegsResponse))
+
+	c, _, err := NewTestClient(t, nil)
+	gock.InterceptClient(&c.HttpClient)
+	defer gock.RestoreClient(&c.HttpClient)
+	c.tokenSource = &FakeTokenSource{}
+
+	allRegs, err := c.ListRegistrations(context.Background(), testKey, testCRN)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, allRegs)
+
+	testKey = "3c44b-f03e6-4y9a5-b859b"
+
+	gock.New("http://example.com").Reply(200).Body(bytes.NewReader(RegsOfKeyResponse))
+
+	regsOfKey, err := c.ListRegistrations(context.Background(), testKey, testCRN)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, regsOfKey)
+	for _, reg := range (*regsOfKey).Registrations {
+		assert.Equal(t, testKey, reg.KeyID)
+	}
+
+	testKey = "2n4y2-4ko2n-4m23f-23j3r"
+	testCRN = "crn:v1:dummy-ennv:dummy-service:global:a/dummy-details:dummy-bucket:dummy-reg"
+
+	gock.New("http://example.com").Reply(200).Body(bytes.NewReader(RegsOfKeyAndCRNResponse))
+
+	regsOfKeyAndCrn, err := c.ListRegistrations(context.Background(), testKey, testCRN)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, regsOfKeyAndCrn)
+	for _, reg := range (*regsOfKeyAndCrn).Registrations {
+		assert.Equal(t, testKey, reg.KeyID)
+		assert.Equal(t, testCRN, reg.ResourceCrn)
+	}
+
+	testKey = ""
+
+	gock.New("http://example.com").Reply(200).Body(bytes.NewReader(RegsOfCRNResponse))
+
+	regsOfCRN, err := c.ListRegistrations(context.Background(), testKey, testCRN)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, regsOfCRN)
+	for _, reg := range (*regsOfCRN).Registrations {
+		assert.Equal(t, testCRN, reg.ResourceCrn)
+	}
+
+	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
+}

--- a/registrations.go
+++ b/registrations.go
@@ -1,0 +1,69 @@
+// Copyright 2020 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kp
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// Registration represents the registration as returned by KP API
+type Registration struct {
+	KeyID              string     `json:"keyId,omitempty"`
+	ResourceCrn        string     `json:"resourceCrn,omitempty"`
+	CreatedBy          string     `json:"createdBy,omitempty"`
+	CreationDate       *time.Time `json:"creationDate,omitempty"`
+	UpdatedBy          string     `json:"updatedBy,omitempty"`
+	LastUpdateDate     *time.Time `json:"lastUpdated,omitempty"`
+	Description        string     `json:"description,omitempty"`
+	PreventKeyDeletion bool       `json:"preventKeyDeletion,omitempty"`
+	KeyVersion         KeyVersion `json:"keyVersion,omitempty"`
+}
+
+type registrations struct {
+	Metadata      KeysMetadata   `json:"metadata"`
+	Registrations []Registration `json:"resources"`
+}
+
+// ListRegistrations retrieves a collection of registrations
+func (c *Client) ListRegistrations(ctx context.Context, keyId, crn string) (*registrations, error) {
+	registrationAPI := ""
+	if keyId != "" {
+		registrationAPI = fmt.Sprintf("keys/%s/registrations", keyId)
+	} else {
+		registrationAPI = "keys/registrations"
+	}
+
+	req, err := c.newRequest("GET", registrationAPI, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if crn != "" {
+		v := url.Values{}
+		v.Set("urlEncodedResourceCRNQuery", crn)
+		req.URL.RawQuery = v.Encode()
+	}
+
+	regs := registrations{}
+	_, err = c.do(ctx, req, &regs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &regs, nil
+}


### PR DESCRIPTION
Associated with the issue :KEYP-4955
Changes included in the PR: Added methods to list registrations of a key and list registrations of any key