### PR TITLE
Dual Auth Key Policy

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -30,6 +30,8 @@ const (
 
 	keyType    = "application/vnd.ibm.kms.key+json"
 	policyType = "application/vnd.ibm.kms.policy+json"
+
+	RotationPolicy = "Rotation"
 )
 
 var (
@@ -370,9 +372,16 @@ type Policy struct {
 	CRN       string     `json:"crn,omitempty"`
 	UpdatedAt *time.Time `json:"lastUpdateDate,omitempty"`
 	UpdatedBy string     `json:"updatedBy,omitempty"`
-	Rotation  struct {
-		Interval int `json:"interval_month,omitempty"`
-	} `json:"rotation,omitempty"`
+	Rotation  *Rotation  `json:"rotation,omitempty"`
+	DualAuth  *DualAuth  `json:"dualAuthDelete,omitempty"`
+}
+
+type Rotation struct {
+	Interval int `json:"interval_month,omitempty"`
+}
+
+type DualAuth struct {
+	Enabled *bool `json:"enabled,omitempty"`
 }
 
 // PoliciesMetadata represents the metadata of a collection of keys.
@@ -388,7 +397,7 @@ type Policies struct {
 }
 
 // GetPolicy retrieves a policy by Key ID.
-func (c *Client) GetPolicy(ctx context.Context, id string) (*Policy, error) {
+func (c *Client) GetPolicy(ctx context.Context, id string) ([]Policy, error) {
 	policyresponse := Policies{}
 
 	req, err := c.newRequest("GET", fmt.Sprintf("keys/%s/policies", id), nil)
@@ -401,20 +410,27 @@ func (c *Client) GetPolicy(ctx context.Context, id string) (*Policy, error) {
 		return nil, err
 	}
 
-	return &policyresponse.Policies[0], nil
+	return policyresponse.Policies, nil
 }
 
 // SetPolicy updates a policy resource by specifying the ID of the key and the rotation interval needed.
-func (c *Client) SetPolicy(ctx context.Context, id string, prefer PreferReturn, rotationInterval int) (*Policy, error) {
+func (c *Client) SetPolicy(ctx context.Context, id, policySetType string, rotationInterval int, dualAuthEnable bool) (*Policy, error) {
 
 	policy := Policy{
 		Type: policyType,
 	}
-	policy.Rotation.Interval = rotationInterval
+
+	if policySetType == RotationPolicy {
+		policy.Rotation = new(Rotation)
+		policy.Rotation.Interval = rotationInterval
+	} else if policySetType == DualAuthDelete {
+		policy.DualAuth = new(DualAuth)
+		policy.DualAuth.Enabled = &dualAuthEnable
+	}
 
 	policyRequest := Policies{
 		Metadata: PoliciesMetadata{
-			CollectionType:   keyType,
+			CollectionType:   policyType,
 			NumberOfPolicies: 1,
 		},
 		Policies: []Policy{policy},
@@ -426,9 +442,6 @@ func (c *Client) SetPolicy(ctx context.Context, id string, prefer PreferReturn, 
 	if err != nil {
 		return nil, err
 	}
-
-	req.Header.Set("Prefer", preferHeaders[prefer])
-
 	_, err = c.do(ctx, req, &policyresponse)
 	if err != nil {
 		return nil, err

--- a/kp_test.go
+++ b/kp_test.go
@@ -1564,4 +1564,6 @@ func TestGetKeyPolicies(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, policies)
 	assert.Equal(t, len(policies), 2)
+
+	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
 }

--- a/kp_test.go
+++ b/kp_test.go
@@ -771,63 +771,63 @@ func TestMisc(t *testing.T) {
 
 // Tests the API methods for policies.
 //
-func TestPolicies(t *testing.T) {
-	testKey := "2n4y2-4ko2n-4m23f-23j3r"
-	testKeys := &Keys{
-		Metadata: KeysMetadata{
-			CollectionType: "json",
-			NumberOfKeys:   2,
-		},
-		Keys: []Key{
-			Key{
-				ID:          testKey,
-				Name:        "Key1",
-				Extractable: false,
-			},
-			Key{
-				ID:          "5ngy2-kko9n-4mj5f-w3jer",
-				Name:        "Key2",
-				Extractable: true,
-			},
-		},
-	}
-	keyURL := NewTestURL("/api/v2/keys")
+// func TestPolicies(t *testing.T) {
+// 	testKey := "2n4y2-4ko2n-4m23f-23j3r"
+// 	testKeys := &Keys{
+// 		Metadata: KeysMetadata{
+// 			CollectionType: "json",
+// 			NumberOfKeys:   2,
+// 		},
+// 		Keys: []Key{
+// 			Key{
+// 				ID:          testKey,
+// 				Name:        "Key1",
+// 				Extractable: false,
+// 			},
+// 			Key{
+// 				ID:          "5ngy2-kko9n-4mj5f-w3jer",
+// 				Name:        "Key2",
+// 				Extractable: true,
+// 			},
+// 		},
+// 	}
+// 	keyURL := NewTestURL("/api/v2/keys")
 
-	cases := TestCases{
-		{
-			"Policy Replace",
-			func(t *testing.T, api *API, ctx context.Context) error {
-				MockAuthURL(keyURL, http.StatusOK, testKeys)
-				MockAuthURL("/api/v2/keys/"+testKey+"/policies", http.StatusOK, testKeys)
+// 	cases := TestCases{
+// {
+// 	"Policy Replace",
+// 	func(t *testing.T, api *API, ctx context.Context) error {
+// 		MockAuthURL(keyURL, http.StatusOK, testKeys)
+// 		MockAuthURL("/api/v2/keys/"+testKey+"/policies", http.StatusOK, testKeys)
 
-				_, err := api.SetPolicy(ctx, testKey, ReturnMinimal, 3)
-				assert.NoError(t, err)
+// 		_, err := api.SetPolicy(ctx, testKey, ReturnMinimal, 3)
+// 		assert.NoError(t, err)
 
-				_, err = api.SetPolicy(ctx, "", ReturnMinimal, 3)
-				assert.Error(t, err)
+// 		_, err = api.SetPolicy(ctx, "", ReturnMinimal, 3)
+// 		assert.Error(t, err)
 
-				return nil
-			},
-		},
-		{
-			"Policy Get",
-			func(t *testing.T, api *API, ctx context.Context) error {
-				MockAuthURL(keyURL, http.StatusOK, testKeys)
-				MockAuthURL("/api/v2/keys/"+testKey+"/policies", http.StatusOK, testKeys)
+// 		return nil
+// 	},
+// },
+// {
+// 	"Policy Get",
+// 	func(t *testing.T, api *API, ctx context.Context) error {
+// 		MockAuthURL(keyURL, http.StatusOK, testKeys)
+// 		MockAuthURL("/api/v2/keys/"+testKey+"/policies", http.StatusOK, testKeys)
 
-				_, err := api.GetPolicy(ctx, testKey)
-				assert.NoError(t, err)
+// 		_, err := api.GetPolicy(ctx, testKey)
+// 		assert.NoError(t, err)
 
-				_, err = api.GetPolicy(ctx, "")
-				assert.Error(t, err)
+// 		_, err = api.GetPolicy(ctx, "")
+// 		assert.Error(t, err)
 
-				return nil
-			},
-		},
-	}
-	cases.Run(t)
+// 		return nil
+// 	},
+// },
+// 	}
+// 	cases.Run(t)
 
-}
+// }
 
 // Tests the API methods for instance policies.
 //
@@ -1506,6 +1506,72 @@ func TestRestoreKey(t *testing.T) {
 	assert.Equal(t, testKey, key.ID)
 	assert.False(t, key.Extractable)
 	assert.Equal(t, key.State, 1)
+
+	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
+}
+
+func TestSetKeyPolicies(t *testing.T) {
+	defer gock.Off()
+	testKey := "2n4y2-4ko2n-4m23f-23j3r"
+	dualAuthPolicyResponse := []byte(`{
+		"metadata":{
+			"collectionType":"application/vnd.ibm.kms.policy+json",
+			"collectionTotal":1
+		},
+		"resources":[
+			{
+				"id":"2n4y2-4ko2n-4m23f-23j3r",
+				"crn":"crn:v1:staging:public:kms:us-south:a/07214fad6bb9305647dc3ebe3244b781:415fe040-f26f-4905-a67e-1ce94a2dfc49:policy:9bf2d029-60e2-4cc6-82d7-a90071642ed2",
+				"dualAuthDelete":{
+					"enabled":true
+				},
+				"createdBy":"IBMid-50BE1MTM26",
+				"creationDate":"2020-05-07T21:53:51Z",
+				"updatedBy":"IBMid-50BE1MTM26",
+				"lastUpdateDate":"2020-05-07T21:53:51Z"
+			}
+		]
+	}`)
+	rotationPolicyResponse := []byte(`{
+		"metadata":{
+			"collectionType":"application/vnd.ibm.kms.policy+json",
+			"collectionTotal":1
+		},
+		"resources":[
+			{
+				"id":"2n4y2-4ko2n-4m23f-23j3r",
+				"crn":"crn:v1:staging:public:kms:us-south:a/07214fad6bb9305647dc3ebe3244b781:415fe040-f26f-4905-a67e-1ce94a2dfc49:policy:29482407-6e3c-4f14-b6b5-caceadd71b45",
+				"rotation":{
+					"interval_month":6
+				},
+				"createdBy":"IBMid-50BE1MTM26",
+				"creationDate":"2020-05-07T21:52:22Z",
+				"updatedBy":"IBMid-50BE1MTM26",
+				"lastUpdateDate":"2020-05-08T03:55:52Z"
+			}
+		]
+	}`)
+
+	gock.New("http://example.com").Reply(200).Body(bytes.NewReader(dualAuthPolicyResponse))
+
+	c, _, err := NewTestClient(t, nil)
+	gock.InterceptClient(&c.HttpClient)
+	defer gock.RestoreClient(&c.HttpClient)
+	c.tokenSource = &FakeTokenSource{}
+
+	dualAuthPolicy, err := c.SetPolicy(context.Background(), testKey, DualAuthDelete, 0, true)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, dualAuthPolicy)
+	assert.True(t, *(dualAuthPolicy.DualAuth.Enabled))
+
+	gock.New("http://example.com").Reply(200).Body(bytes.NewReader(rotationPolicyResponse))
+
+	rotationPolicy, err := c.SetPolicy(context.Background(), testKey, RotationPolicy, 4, false)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, rotationPolicy)
+	assert.Equal(t, 6, rotationPolicy.Rotation.Interval)
 
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
 }

--- a/kp_test.go
+++ b/kp_test.go
@@ -769,66 +769,6 @@ func TestMisc(t *testing.T) {
 	cases.Run(t)
 }
 
-// Tests the API methods for policies.
-//
-// func TestPolicies(t *testing.T) {
-// 	testKey := "2n4y2-4ko2n-4m23f-23j3r"
-// 	testKeys := &Keys{
-// 		Metadata: KeysMetadata{
-// 			CollectionType: "json",
-// 			NumberOfKeys:   2,
-// 		},
-// 		Keys: []Key{
-// 			Key{
-// 				ID:          testKey,
-// 				Name:        "Key1",
-// 				Extractable: false,
-// 			},
-// 			Key{
-// 				ID:          "5ngy2-kko9n-4mj5f-w3jer",
-// 				Name:        "Key2",
-// 				Extractable: true,
-// 			},
-// 		},
-// 	}
-// 	keyURL := NewTestURL("/api/v2/keys")
-
-// 	cases := TestCases{
-// {
-// 	"Policy Replace",
-// 	func(t *testing.T, api *API, ctx context.Context) error {
-// 		MockAuthURL(keyURL, http.StatusOK, testKeys)
-// 		MockAuthURL("/api/v2/keys/"+testKey+"/policies", http.StatusOK, testKeys)
-
-// 		_, err := api.SetPolicy(ctx, testKey, ReturnMinimal, 3)
-// 		assert.NoError(t, err)
-
-// 		_, err = api.SetPolicy(ctx, "", ReturnMinimal, 3)
-// 		assert.Error(t, err)
-
-// 		return nil
-// 	},
-// },
-// {
-// 	"Policy Get",
-// 	func(t *testing.T, api *API, ctx context.Context) error {
-// 		MockAuthURL(keyURL, http.StatusOK, testKeys)
-// 		MockAuthURL("/api/v2/keys/"+testKey+"/policies", http.StatusOK, testKeys)
-
-// 		_, err := api.GetPolicy(ctx, testKey)
-// 		assert.NoError(t, err)
-
-// 		_, err = api.GetPolicy(ctx, "")
-// 		assert.Error(t, err)
-
-// 		return nil
-// 	},
-// },
-// 	}
-// 	cases.Run(t)
-
-// }
-
 // Tests the API methods for instance policies.
 //
 func TestInstancePolicies(t *testing.T) {
@@ -1510,6 +1450,7 @@ func TestRestoreKey(t *testing.T) {
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
 }
 
+// TestSetKeyPolicies tests the method SetPolicy which makes a request to Key Protect API to set Policies for a key
 func TestSetKeyPolicies(t *testing.T) {
 	defer gock.Off()
 	testKey := "2n4y2-4ko2n-4m23f-23j3r"
@@ -1520,14 +1461,14 @@ func TestSetKeyPolicies(t *testing.T) {
 		},
 		"resources":[
 			{
-				"id":"2n4y2-4ko2n-4m23f-23j3r",
-				"crn":"crn:v1:staging:public:kms:us-south:a/07214fad6bb9305647dc3ebe3244b781:415fe040-f26f-4905-a67e-1ce94a2dfc49:policy:9bf2d029-60e2-4cc6-82d7-a90071642ed2",
+				"id":"9bfye029-60e2-4cc6-82d7-a900716",
+				"crn":"crn:v5:dummy-env:dummy-service:dummy-region:dummy-details::",
 				"dualAuthDelete":{
 					"enabled":true
 				},
-				"createdBy":"IBMid-50BE1MTM26",
+				"createdBy":"test_user3",
 				"creationDate":"2020-05-07T21:53:51Z",
-				"updatedBy":"IBMid-50BE1MTM26",
+				"updatedBy":"test_user3",
 				"lastUpdateDate":"2020-05-07T21:53:51Z"
 			}
 		]
@@ -1539,14 +1480,14 @@ func TestSetKeyPolicies(t *testing.T) {
 		},
 		"resources":[
 			{
-				"id":"2n4y2-4ko2n-4m23f-23j3r",
-				"crn":"crn:v1:staging:public:kms:us-south:a/07214fad6bb9305647dc3ebe3244b781:415fe040-f26f-4905-a67e-1ce94a2dfc49:policy:29482407-6e3c-4f14-b6b5-caceadd71b45",
+				"id":"er482407-6e3c-4f14-56b5-caceadd",
+				"crn":"crn:v5:dummy-env:dummy-service:dummy-region:dummy-details::",
 				"rotation":{
 					"interval_month":6
 				},
-				"createdBy":"IBMid-50BE1MTM26",
+				"createdBy":"test_user3",
 				"creationDate":"2020-05-07T21:52:22Z",
-				"updatedBy":"IBMid-50BE1MTM26",
+				"updatedBy":"test_user3",
 				"lastUpdateDate":"2020-05-08T03:55:52Z"
 			}
 		]
@@ -1574,4 +1515,53 @@ func TestSetKeyPolicies(t *testing.T) {
 	assert.Equal(t, 6, rotationPolicy.Rotation.Interval)
 
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
+}
+
+// TestGetKeyPolicies tests the GetPolicy method which makes a request to Key Protect end point to retrieve key policies
+func TestGetKeyPolicies(t *testing.T) {
+	defer gock.Off()
+	testKey := "2n4y2-4ko2n-4m23f-23j3r"
+	getPoliciesResponse := []byte(`{
+		"metadata":{
+			"collectionType":"application/vnd.ibm.kms.policy+json",
+			"collectionTotal":2
+		},
+		"resources":[
+			{
+				"id":"er482407-6e3c-4f14-56b5-caceadd",
+				"crn":"crn:v5:dummy-env:dummy-service:dummy-region:dummy-details::",
+				"rotation":{
+				"interval_month":6
+				},
+				"createdBy":"test_user3",
+				"creationDate":"2020-05-07T21:52:22Z",
+				"updatedBy":"test_user3",
+				"lastUpdateDate":"2020-05-08T03:55:52Z"
+			},
+			{
+				"id":"9bfye029-60e2-4cc6-82d7-a900716",
+				"crn":"crn:v5:dummy-env:dummy-service:dummy-region:dummy-details::",
+				"dualAuthDelete":{
+					"enabled":false
+				},
+				"createdBy":"test_user3",
+				"creationDate":"2020-05-07T21:53:51Z",
+				"updatedBy":"test_user3",
+				"lastUpdateDate":"2020-05-07T21:53:51Z"
+			}
+		]
+	}`)
+
+	gock.New("http://example.com").Reply(200).Body(bytes.NewReader(getPoliciesResponse))
+
+	c, _, err := NewTestClient(t, nil)
+	gock.InterceptClient(&c.HttpClient)
+	defer gock.RestoreClient(&c.HttpClient)
+	c.tokenSource = &FakeTokenSource{}
+
+	policies, err := c.GetPolicy(context.Background(), testKey)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, policies)
+	assert.Equal(t, len(policies), 2)
 }

--- a/policy.go
+++ b/policy.go
@@ -1,0 +1,120 @@
+// Copyright 2020 IBM Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kp
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+const (
+	policyType = "application/vnd.ibm.kms.policy+json"
+
+	RotationPolicy = "rotation"
+)
+
+// Policy represents a policy as returned by the KP API.
+type Policy struct {
+	Type      string     `json:"type,omitempty"`
+	CreatedBy string     `json:"createdBy,omitempty"`
+	CreatedAt *time.Time `json:"creationDate,omitempty"`
+	CRN       string     `json:"crn,omitempty"`
+	UpdatedAt *time.Time `json:"lastUpdateDate,omitempty"`
+	UpdatedBy string     `json:"updatedBy,omitempty"`
+	Rotation  *Rotation  `json:"rotation,omitempty"`
+	DualAuth  *DualAuth  `json:"dualAuthDelete,omitempty"`
+}
+
+type Rotation struct {
+	Interval int `json:"interval_month,omitempty"`
+}
+
+type DualAuth struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// PoliciesMetadata represents the metadata of a collection of keys.
+type PoliciesMetadata struct {
+	CollectionType   string `json:"collectionType"`
+	NumberOfPolicies int    `json:"collectionTotal"`
+}
+
+// Policies represents a collection of Policies.
+type Policies struct {
+	Metadata PoliciesMetadata `json:"metadata"`
+	Policies []Policy         `json:"resources"`
+}
+
+// GetPolicy retrieves a policy by Key ID.
+func (c *Client) GetPolicy(ctx context.Context, id, policyType string) ([]Policy, error) {
+	policyresponse := Policies{}
+
+	req, err := c.newRequest("GET", fmt.Sprintf("keys/%s/policies", id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if policyType != "" && (policyType == RotationPolicy || policyType == DualAuthDelete) {
+		v := url.Values{}
+		v.Set("policy", policyType)
+		req.URL.RawQuery = v.Encode()
+	}
+
+	_, err = c.do(ctx, req, &policyresponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return policyresponse.Policies, nil
+}
+
+// SetPolicy updates a policy resource by specifying the ID of the key and the rotation interval needed.
+func (c *Client) SetPolicy(ctx context.Context, id, policySetType string, rotationInterval int, dualAuthEnable bool) (*Policy, error) {
+
+	policy := Policy{
+		Type: policyType,
+	}
+
+	if policySetType == RotationPolicy {
+		policy.Rotation = new(Rotation)
+		policy.Rotation.Interval = rotationInterval
+	} else if policySetType == DualAuthDelete {
+		policy.DualAuth = new(DualAuth)
+		policy.DualAuth.Enabled = &dualAuthEnable
+	}
+
+	policyRequest := Policies{
+		Metadata: PoliciesMetadata{
+			CollectionType:   policyType,
+			NumberOfPolicies: 1,
+		},
+		Policies: []Policy{policy},
+	}
+
+	policyresponse := Policies{}
+
+	req, err := c.newRequest("PUT", fmt.Sprintf("keys/%s/policies", id), &policyRequest)
+	if err != nil {
+		return nil, err
+	}
+	_, err = c.do(ctx, req, &policyresponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &policyresponse.Policies[0], nil
+}

--- a/policy.go
+++ b/policy.go
@@ -120,12 +120,6 @@ func (c *Client) GetPolicies(ctx context.Context, id string) ([]Policy, error) {
 		return nil, err
 	}
 
-	if policyType != "" && (policyType == RotationPolicy || policyType == DualAuthDelete) {
-		v := url.Values{}
-		v.Set("policy", policyType)
-		req.URL.RawQuery = v.Encode()
-	}
-
 	_, err = c.do(ctx, req, &policyresponse)
 	if err != nil {
 		return nil, err

--- a/policy.go
+++ b/policy.go
@@ -60,7 +60,57 @@ type Policies struct {
 }
 
 // GetPolicy retrieves a policy by Key ID.
-func (c *Client) GetPolicy(ctx context.Context, id, policyType string) ([]Policy, error) {
+func (c *Client) GetPolicy(ctx context.Context, id string) (*Policy, error) {
+	policyresponse := Policies{}
+
+	req, err := c.newRequest("GET", fmt.Sprintf("keys/%s/policies", id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = c.do(ctx, req, &policyresponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &policyresponse.Policies[0], nil
+}
+
+// SetPolicy updates a policy resource by specifying the ID of the key and the rotation interval needed.
+func (c *Client) SetPolicy(ctx context.Context, id string, prefer PreferReturn, rotationInterval int) (*Policy, error) {
+
+	policy := Policy{
+		Type: policyType,
+	}
+	policy.Rotation.Interval = rotationInterval
+
+	policyRequest := Policies{
+		Metadata: PoliciesMetadata{
+			CollectionType:   keyType,
+			NumberOfPolicies: 1,
+		},
+		Policies: []Policy{policy},
+	}
+
+	policyresponse := Policies{}
+
+	req, err := c.newRequest("PUT", fmt.Sprintf("keys/%s/policies", id), &policyRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Prefer", preferHeaders[prefer])
+
+	_, err = c.do(ctx, req, &policyresponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &policyresponse.Policies[0], nil
+}
+
+// GetPolicies retrieves a policy by Key ID.
+func (c *Client) GetPolicies(ctx context.Context, id string) ([]Policy, error) {
 	policyresponse := Policies{}
 
 	req, err := c.newRequest("GET", fmt.Sprintf("keys/%s/policies", id), nil)
@@ -82,19 +132,63 @@ func (c *Client) GetPolicy(ctx context.Context, id, policyType string) ([]Policy
 	return policyresponse.Policies, nil
 }
 
-// SetPolicy updates a policy resource by specifying the ID of the key and the rotation interval needed.
-func (c *Client) SetPolicy(ctx context.Context, id, policySetType string, rotationInterval int, dualAuthEnable bool) (*Policy, error) {
+// GetRotationPolivy method retrieves rotation policy details of a key
+func (c *Client) GetRotationPolicy(ctx context.Context, id string) (*Policy, error) {
+	policyresponse := Policies{}
 
-	policy := Policy{
-		Type: policyType,
+	req, err := c.newRequest("GET", fmt.Sprintf("keys/%s/policies", id), nil)
+	if err != nil {
+		return nil, err
 	}
 
-	if policySetType == RotationPolicy {
-		policy.Rotation = new(Rotation)
-		policy.Rotation.Interval = rotationInterval
-	} else if policySetType == DualAuthDelete {
-		policy.DualAuth = new(DualAuth)
-		policy.DualAuth.Enabled = &dualAuthEnable
+	v := url.Values{}
+	v.Set("policy", RotationPolicy)
+	req.URL.RawQuery = v.Encode()
+
+	_, err = c.do(ctx, req, &policyresponse)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(policyresponse.Policies) == 0 {
+		return nil, nil
+	}
+
+	return &policyresponse.Policies[0], nil
+}
+
+// GetDualAuthDeletePolicy method retrieves dual auth delete policy details of a key
+func (c *Client) GetDualAuthDeletePolicy(ctx context.Context, id string) (*Policy, error) {
+	policyresponse := Policies{}
+
+	req, err := c.newRequest("GET", fmt.Sprintf("keys/%s/policies", id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v := url.Values{}
+	v.Set("policy", DualAuthDelete)
+	req.URL.RawQuery = v.Encode()
+
+	_, err = c.do(ctx, req, &policyresponse)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(policyresponse.Policies) == 0 {
+		return nil, nil
+	}
+
+	return &policyresponse.Policies[0], nil
+}
+
+// SetRotationPolicy updates the rotation policy associated with a key by specifying key ID and rotation interval
+func (c *Client) SetRotationPolicy(ctx context.Context, id string, rotationInterval int) (*Policy, error) {
+	policy := Policy{
+		Type: policyType,
+		Rotation: &Rotation{
+			Interval: rotationInterval,
+		},
 	}
 
 	policyRequest := Policies{
@@ -111,10 +205,106 @@ func (c *Client) SetPolicy(ctx context.Context, id, policySetType string, rotati
 	if err != nil {
 		return nil, err
 	}
+
+	v := url.Values{}
+	v.Set("policy", RotationPolicy)
+	req.URL.RawQuery = v.Encode()
+
 	_, err = c.do(ctx, req, &policyresponse)
 	if err != nil {
 		return nil, err
 	}
 
+	if len(policyresponse.Policies) == 0 {
+		return nil, nil
+	}
+
 	return &policyresponse.Policies[0], nil
+}
+
+// SetDualAuthDeletePolicy updates the dual auth delete policy by passing the key ID and enable detail
+func (c *Client) SetDualAuthDeletePolicy(ctx context.Context, id string, enabled bool) (*Policy, error) {
+	policy := Policy{
+		Type: policyType,
+		DualAuth: &DualAuth{
+			Enabled: &enabled,
+		},
+	}
+
+	policyRequest := Policies{
+		Metadata: PoliciesMetadata{
+			CollectionType:   policyType,
+			NumberOfPolicies: 1,
+		},
+		Policies: []Policy{policy},
+	}
+
+	policyresponse := Policies{}
+
+	req, err := c.newRequest("PUT", fmt.Sprintf("keys/%s/policies", id), &policyRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	v := url.Values{}
+	v.Set("policy", DualAuthDelete)
+	req.URL.RawQuery = v.Encode()
+
+	_, err = c.do(ctx, req, &policyresponse)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(policyresponse.Policies) == 0 {
+		return nil, nil
+	}
+
+	return &policyresponse.Policies[0], nil
+}
+
+// SetPolicies updates all policies of the key or a single policy by passing key ID.
+// To set rotation policy for the key pass the setRotationPolicy parameter as true and set the rotationInterval detail.
+// To set dual auth delete policy for the key pass the setDualAuthDeletePolicy parameter as true and set the dualAuthEnable detail.
+// Both the policies can be set or either of the policies can be set.
+func (c *Client) SetPolicies(ctx context.Context, id string, setRotationPolicy bool, rotationInterval int, setDualAuthDeletePolicy, dualAuthEnable bool) ([]Policy, error) {
+	policies := []Policy{}
+	if setRotationPolicy {
+		rotationPolicy := Policy{
+			Type: policyType,
+			Rotation: &Rotation{
+				Interval: rotationInterval,
+			},
+		}
+		policies = append(policies, rotationPolicy)
+	}
+	if setDualAuthDeletePolicy {
+		dulaAuthPolicy := Policy{
+			Type: policyType,
+			DualAuth: &DualAuth{
+				Enabled: &dualAuthEnable,
+			},
+		}
+		policies = append(policies, dulaAuthPolicy)
+	}
+
+	policyRequest := Policies{
+		Metadata: PoliciesMetadata{
+			CollectionType:   policyType,
+			NumberOfPolicies: len(policies),
+		},
+		Policies: policies,
+	}
+
+	policyresponse := Policies{}
+
+	req, err := c.newRequest("PUT", fmt.Sprintf("keys/%s/policies", id), &policyRequest)
+	if err != nil {
+		return nil, err
+	}
+	_, err = c.do(ctx, req, &policyresponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return policyresponse.Policies, nil
 }

--- a/policy.go
+++ b/policy.go
@@ -81,12 +81,14 @@ func (c *Client) SetPolicy(ctx context.Context, id string, prefer PreferReturn, 
 
 	policy := Policy{
 		Type: policyType,
+		Rotation: &Rotation{
+			Interval: rotationInterval,
+		},
 	}
-	policy.Rotation.Interval = rotationInterval
 
 	policyRequest := Policies{
 		Metadata: PoliciesMetadata{
-			CollectionType:   keyType,
+			CollectionType:   policyType,
 			NumberOfPolicies: 1,
 		},
 		Policies: []Policy{policy},

--- a/policy.go
+++ b/policy.go
@@ -59,7 +59,11 @@ type Policies struct {
 	Policies []Policy         `json:"resources"`
 }
 
-// GetPolicy retrieves a policy by Key ID.
+// GetPolicy retrieves a policy by Key ID. This function is
+// deprecated, as it only returns one policy and does not let you
+// select which policy set it will return. It is kept for backward
+// compatibility on keys with only one rotation policy. Please update
+// to use the new GetPolicies or Get<type>Policy functions.
 func (c *Client) GetPolicy(ctx context.Context, id string) (*Policy, error) {
 	policyresponse := Policies{}
 
@@ -76,7 +80,10 @@ func (c *Client) GetPolicy(ctx context.Context, id string) (*Policy, error) {
 	return &policyresponse.Policies[0], nil
 }
 
-// SetPolicy updates a policy resource by specifying the ID of the key and the rotation interval needed.
+// SetPolicy updates a policy resource by specifying the ID of the key and
+// the rotation interval needed. This function is deprecated as it will only
+// let you set key rotation  policies. To set dual auth and other newer policies
+// on a key, please use the new SetPolicies of Set<type>Policy functions.
 func (c *Client) SetPolicy(ctx context.Context, id string, prefer PreferReturn, rotationInterval int) (*Policy, error) {
 
 	policy := Policy{


### PR DESCRIPTION
Associated with the issue : KEYP-4956
Changes included in the PR: Allows setting of dual auth key policy along with rotation policy, Retrieves all the policies associated with a key. Updated the unit tests accordingly."