### PR TITLE
fix panic, return an error if no policies were found

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -17,6 +17,7 @@ package kp
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"log"
 	"net/url"
@@ -353,6 +354,10 @@ func (c *Client) GetPolicy(ctx context.Context, id string) (*Policy, error) {
 	_, err = c.do(ctx, req, &policyresponse)
 	if err != nil {
 		return nil, err
+	}
+
+	if policyresponse.Policies == nil {
+		return nil, errors.New("No policies")
 	}
 
 	return &policyresponse.Policies[0], nil

--- a/kp_test.go
+++ b/kp_test.go
@@ -63,7 +63,7 @@ func NewTestClient(t *testing.T, c *ClientConfig) (*API, context.Context, error)
 	return api, context.Background(), err
 }
 
-// MockAuthURL mocks an api endpoint.
+// MockURL mocks an api endpoint.
 //
 func MockURL(url string, status int, json interface{}) *gock.Response {
 	return gock.New(url).Reply(status).JSON(json)


### PR DESCRIPTION
### Description

If a root key is created with no policies, a panic error is created when accessing index 0 (zero) in this statement: `return &policyresponse.Policies[0], nil`.

### Reproduce

Using the `kp` plugin for `ibmcloud`, these two commands will trigger a panic error.

```bash
$ ibmcloud kp key create my-root-key
(capture the Key ID)

$ ibmcloud kp key policies $KEY_ID
Retrieving policy details for key ID: $KEY_ID...

panic: runtime error: index out of range [0] with length 0
```