### PR TITLE
Set unset key for deletion

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -362,26 +362,32 @@ func (c *Client) Rotate(ctx context.Context, id, payload string) error {
 	return nil
 }
 
-// Set key for deletion.
+// InitiateDualAuthDelete sets a key for deletion. The key must be configured with a DualAuthDelete policy.
+// After the key is set to deletion it can be deleted by another user who has Manager access.
+// For more information refer to the Key Protect docs in the link below:
+// https://cloud.ibm.com/docs/key-protect?topic=key-protect-delete-dual-auth-keys#set-key-deletion-api
 func (c *Client) InitiateDualAuthDelete(ctx context.Context, id string) error {
 
-        _, err := c.doKeysAction(ctx, id, "setKeyForDeletion", nil)
-        if err != nil {
-                return err
-        }
+	_, err := c.doKeysAction(ctx, id, "setKeyForDeletion", nil)
+	if err != nil {
+		return err
+	}
 
-        return nil
+	return err
 }
 
-// Unset key for deletion.
+// CancelDualAuthDelete unsets the key for deletion. If a key is set for deletion, it can
+// be prevented from getting deleted by unsetting the key for deletion.
+// For more information refer to the Key Protect docs in the link below:
+//https://cloud.ibm.com/docs/key-protect?topic=key-protect-delete-dual-auth-keys#unset-key-deletion-api
 func (c *Client) CancelDualAuthDelete(ctx context.Context, id string) error {
 
-        _, err := c.doKeysAction(ctx, id, "unsetKeyForDeletion", nil)
-        if err != nil {
-                return err
-        }
+	_, err := c.doKeysAction(ctx, id, "unsetKeyForDeletion", nil)
+	if err != nil {
+		return err
+	}
 
-        return nil
+	return err
 }
 
 // Policy represents a policy as returned by the KP API.

--- a/keys.go
+++ b/keys.go
@@ -363,7 +363,7 @@ func (c *Client) Rotate(ctx context.Context, id, payload string) error {
 }
 
 // Set key for deletion.
-func (c *Client) SetKeyForDeletion(ctx context.Context, id string) error {
+func (c *Client) InitiateDualAuthDelete(ctx context.Context, id string) error {
 
         _, err := c.doKeysAction(ctx, id, "setKeyForDeletion", nil)
         if err != nil {
@@ -374,7 +374,7 @@ func (c *Client) SetKeyForDeletion(ctx context.Context, id string) error {
 }
 
 // Unset key for deletion.
-func (c *Client) UnsetKeyForDeletion(ctx context.Context, id string) error {
+func (c *Client) CancelDualAuthDelete(ctx context.Context, id string) error {
 
         _, err := c.doKeysAction(ctx, id, "unsetKeyForDeletion", nil)
         if err != nil {

--- a/keys.go
+++ b/keys.go
@@ -362,6 +362,28 @@ func (c *Client) Rotate(ctx context.Context, id, payload string) error {
 	return nil
 }
 
+// Set key for deletion.
+func (c *Client) SetKeyForDeletion(ctx context.Context, id string) error {
+
+        _, err := c.doKeysAction(ctx, id, "setKeyForDeletion", nil)
+        if err != nil {
+                return err
+        }
+
+        return nil
+}
+
+// Unset key for deletion.
+func (c *Client) UnsetKeyForDeletion(ctx context.Context, id string) error {
+
+        _, err := c.doKeysAction(ctx, id, "unsetKeyForDeletion", nil)
+        if err != nil {
+                return err
+        }
+
+        return nil
+}
+
 // Policy represents a policy as returned by the KP API.
 type Policy struct {
 	Type      string     `json:"type,omitempty"`

--- a/kp_test.go
+++ b/kp_test.go
@@ -1523,7 +1523,7 @@ func TestInitiate_DualAuthDelete(t *testing.T) {
 
 	err = c.InitiateDualAuthDelete(context.Background(), "keyID")
 
-	assert.Nil(t, err)
+	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
 }
 
 func TestCancel_DualAuthDelete(t *testing.T) {
@@ -1540,5 +1540,5 @@ func TestCancel_DualAuthDelete(t *testing.T) {
 
 	err = c.CancelDualAuthDelete(context.Background(), "keyID")
 
-	assert.Nil(t, err)
+	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
 }

--- a/kp_test.go
+++ b/kp_test.go
@@ -672,6 +672,32 @@ func TestKeys(t *testing.T) {
 
 			},
 		},
+                {
+                        "Set Key For Deletion",
+                        func(t *testing.T, api *API, ctx context.Context) error {
+                                MockAuthURL(keyURL, http.StatusOK, testKeys)
+                                MockAuthURL(keyURL, http.StatusServiceUnavailable, testKeys)
+
+                                err = api.SetKeyForDeletion(ctx, "test")
+                                assert.NoError(t, err)
+
+                                return nil
+
+                        },
+                },
+                {
+                        "Unset Key For Deletion",
+                        func(t *testing.T, api *API, ctx context.Context) error {
+                                MockAuthURL(keyURL, http.StatusOK, testKeys)
+                                MockAuthURL(keyURL, http.StatusServiceUnavailable, testKeys)
+
+                                err = api.unSetKeyForDeletion(ctx, "test")
+                                assert.NoError(t, err)
+
+                                return nil
+
+                        },
+                },
 		{
 			"Get Key",
 			func(t *testing.T, api *API, ctx context.Context) error {

--- a/kp_test.go
+++ b/kp_test.go
@@ -1523,6 +1523,8 @@ func TestInitiate_DualAuthDelete(t *testing.T) {
 
 	err = c.InitiateDualAuthDelete(context.Background(), "keyID")
 
+	assert.Nil(t, err)
+	
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
 }
 
@@ -1540,5 +1542,7 @@ func TestCancel_DualAuthDelete(t *testing.T) {
 
 	err = c.CancelDualAuthDelete(context.Background(), "keyID")
 
+	assert.Nil(t, err)
+	
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
 }

--- a/kp_test.go
+++ b/kp_test.go
@@ -1509,10 +1509,11 @@ func TestRestoreKey(t *testing.T) {
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
 }
 
-func TestSetKey_ForDeletion(t *testing.T) {
+func TestInitiate_DualAuthDelete(t *testing.T) {
         defer gock.Off()
 
         gock.New("http://example.com").
+                MatchParam("action", "setKeyForDeletion").
                 Reply(204)
 
         c, _, err := NewTestClient(t, nil)
@@ -1520,15 +1521,16 @@ func TestSetKey_ForDeletion(t *testing.T) {
         defer gock.RestoreClient(&c.HttpClient)
         c.tokenSource = &FakeTokenSource{}
 
-        err = c.SetKeyForDeletion(context.Background(), "keyID")
+        err = c.InitiateDualAuthDelete(context.Background(), "keyID")
 
         assert.Nil(t, err)
 }
 
-func TestUnsetKey_ForDeletion(t *testing.T) {
+func TestCancel_DualAuthDelete(t *testing.T) {
         defer gock.Off()
 
         gock.New("http://example.com").
+                MatchParam("action", "unsetKeyForDeletion")
                 Reply(204)
 
         c, _, err := NewTestClient(t, nil)
@@ -1536,7 +1538,7 @@ func TestUnsetKey_ForDeletion(t *testing.T) {
         defer gock.RestoreClient(&c.HttpClient)
         c.tokenSource = &FakeTokenSource{}
 
-        err = c.UnsetKeyForDeletion(context.Background(), "keyID")
+        err = c.CancelDualAuthDelete(context.Background(), "keyID")
 
         assert.Nil(t, err)
 }

--- a/kp_test.go
+++ b/kp_test.go
@@ -672,32 +672,6 @@ func TestKeys(t *testing.T) {
 
 			},
 		},
-                {
-                        "Set Key For Deletion",
-                        func(t *testing.T, api *API, ctx context.Context) error {
-                                MockAuthURL(keyURL, http.StatusOK, testKeys)
-                                MockAuthURL(keyURL, http.StatusServiceUnavailable, testKeys)
-
-                                err = api.SetKeyForDeletion(ctx, "test")
-                                assert.NoError(t, err)
-
-                                return nil
-
-                        },
-                },
-                {
-                        "Unset Key For Deletion",
-                        func(t *testing.T, api *API, ctx context.Context) error {
-                                MockAuthURL(keyURL, http.StatusOK, testKeys)
-                                MockAuthURL(keyURL, http.StatusServiceUnavailable, testKeys)
-
-                                err = api.unSetKeyForDeletion(ctx, "test")
-                                assert.NoError(t, err)
-
-                                return nil
-
-                        },
-                },
 		{
 			"Get Key",
 			func(t *testing.T, api *API, ctx context.Context) error {
@@ -721,7 +695,6 @@ func TestKeys(t *testing.T) {
 				return nil
 			},
 		},
-
 		{
 			"Wrap Unwrap",
 			func(t *testing.T, api *API, ctx context.Context) error {
@@ -1534,4 +1507,36 @@ func TestRestoreKey(t *testing.T) {
 	assert.Equal(t, key.State, 1)
 
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
+}
+
+func TestSetKey_ForDeletion(t *testing.T) {
+        defer gock.Off()
+
+        gock.New("http://example.com").
+                Reply(204)
+
+        c, _, err := NewTestClient(t, nil)
+        gock.InterceptClient(&c.HttpClient)
+        defer gock.RestoreClient(&c.HttpClient)
+        c.tokenSource = &FakeTokenSource{}
+
+        err = c.SetKeyForDeletion(context.Background(), "keyID")
+
+        assert.Nil(t, err)
+}
+
+func TestUnsetKey_ForDeletion(t *testing.T) {
+        defer gock.Off()
+
+        gock.New("http://example.com").
+                Reply(204)
+
+        c, _, err := NewTestClient(t, nil)
+        gock.InterceptClient(&c.HttpClient)
+        defer gock.RestoreClient(&c.HttpClient)
+        c.tokenSource = &FakeTokenSource{}
+
+        err = c.UnsetKeyForDeletion(context.Background(), "keyID")
+
+        assert.Nil(t, err)
 }

--- a/kp_test.go
+++ b/kp_test.go
@@ -1510,35 +1510,35 @@ func TestRestoreKey(t *testing.T) {
 }
 
 func TestInitiate_DualAuthDelete(t *testing.T) {
-        defer gock.Off()
+	defer gock.Off()
 
-        gock.New("http://example.com").
-                MatchParam("action", "setKeyForDeletion").
-                Reply(204)
+	gock.New("http://example.com").
+		MatchParam("action", "setKeyForDeletion").
+		Reply(204)
 
-        c, _, err := NewTestClient(t, nil)
-        gock.InterceptClient(&c.HttpClient)
-        defer gock.RestoreClient(&c.HttpClient)
-        c.tokenSource = &FakeTokenSource{}
+	c, _, err := NewTestClient(t, nil)
+	gock.InterceptClient(&c.HttpClient)
+	defer gock.RestoreClient(&c.HttpClient)
+	c.tokenSource = &FakeTokenSource{}
 
-        err = c.InitiateDualAuthDelete(context.Background(), "keyID")
+	err = c.InitiateDualAuthDelete(context.Background(), "keyID")
 
-        assert.Nil(t, err)
+	assert.Nil(t, err)
 }
 
 func TestCancel_DualAuthDelete(t *testing.T) {
-        defer gock.Off()
+	defer gock.Off()
 
-        gock.New("http://example.com").
-                MatchParam("action", "unsetKeyForDeletion")
-                Reply(204)
+	gock.New("http://example.com").
+		MatchParam("action", "unsetKeyForDeletion").
+		Reply(204)
 
-        c, _, err := NewTestClient(t, nil)
-        gock.InterceptClient(&c.HttpClient)
-        defer gock.RestoreClient(&c.HttpClient)
-        c.tokenSource = &FakeTokenSource{}
+	c, _, err := NewTestClient(t, nil)
+	gock.InterceptClient(&c.HttpClient)
+	defer gock.RestoreClient(&c.HttpClient)
+	c.tokenSource = &FakeTokenSource{}
 
-        err = c.CancelDualAuthDelete(context.Background(), "keyID")
+	err = c.CancelDualAuthDelete(context.Background(), "keyID")
 
-        assert.Nil(t, err)
+	assert.Nil(t, err)
 }


### PR DESCRIPTION
Associated with the issue : KEYP-5433

Changes included in the PR: added methods for set and unset key for deletion,
added unit tests for the methods. (Done by aneesha)