### PR TITLE
Updated SDK with allowed IP instance policy

### DIFF
--- a/instances.go
+++ b/instances.go
@@ -212,7 +212,7 @@ func (c *Client) SetAllowedIPInstancePolicy(ctx context.Context, enable bool, al
 		policy.PolicyData.Attributes = &Attributes{}
 		policy.PolicyData.Attributes.AllowedIP = allowedIPs
 	} else if enable && len(allowedIPs) == 0 {
-		return fmt.Errorf("Please provide atleast 1 IP subnet specified with CIDR notation")
+		return fmt.Errorf("Please provide at least 1 IP subnet specified with CIDR notation")
 	} else if !enable && len(allowedIPs) != 0 {
 		return fmt.Errorf("IP address list should only be provided if the policy is being enabled")
 	}

--- a/instances.go
+++ b/instances.go
@@ -197,16 +197,16 @@ func (c *Client) SetDualAuthInstancePolicy(ctx context.Context, enable bool) err
 
 // SetAllowedIPInstancePolices updates the allowed IP instance policy details associated with an instance.
 // For more information can refet to the Key Protect docs in the link below:
-// <KP link>
+// https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-allowed-ip
 func (c *Client) SetAllowedIPInstancePolicy(ctx context.Context, enable bool, allowedIPs []string) error {
 	policy := InstancePolicy{
 		PolicyType: AllowedIP,
 		PolicyData: PolicyData{
-			Enabled:    &enable,
-			Attributes: &Attributes{},
+			Enabled: &enable,
 		},
 	}
-	if len(allowedIPs) != 0 {
+	if enable && len(allowedIPs) > 0 {
+		policy.PolicyData.Attributes = &Attributes{}
 		policy.PolicyData.Attributes.AllowedIP = allowedIPs
 	}
 

--- a/instances.go
+++ b/instances.go
@@ -208,15 +208,13 @@ func (c *Client) SetAllowedIPInstancePolicy(ctx context.Context, enable bool, al
 	}
 
 	// The IP address validation is performed by the key protect service.
-	if len(allowedIPs) != 0 {
-		if enable {
-			policy.PolicyData.Attributes = &Attributes{}
-			policy.PolicyData.Attributes.AllowedIP = allowedIPs
-		} else {
-			return fmt.Errorf("Provide IP Addresses only of the policy is being enabled")
-		}
-	} else {
+	if enable && len(allowedIPs) != 0 {
+		policy.PolicyData.Attributes = &Attributes{}
+		policy.PolicyData.Attributes.AllowedIP = allowedIPs
+	} else if enable && len(allowedIPs) == 0 {
 		return fmt.Errorf("Please provide atleast 1 IP Address")
+	} else if !enable && len(allowedIPs) != 0 {
+		return fmt.Errorf("Provide IP Addresses only of the policy is being enabled")
 	}
 
 	policyRequest := InstancePolicies{

--- a/instances.go
+++ b/instances.go
@@ -212,9 +212,9 @@ func (c *Client) SetAllowedIPInstancePolicy(ctx context.Context, enable bool, al
 		policy.PolicyData.Attributes = &Attributes{}
 		policy.PolicyData.Attributes.AllowedIP = allowedIPs
 	} else if enable && len(allowedIPs) == 0 {
-		return fmt.Errorf("Please provide atleast 1 IP Address")
+		return fmt.Errorf("Please provide atleast 1 IP subnet specified with CIDR notation")
 	} else if !enable && len(allowedIPs) != 0 {
-		return fmt.Errorf("Provide IP Addresses only of the policy is being enabled")
+		return fmt.Errorf("IP address list should only be provided if the policy is being enabled")
 	}
 
 	policyRequest := InstancePolicies{

--- a/instances.go
+++ b/instances.go
@@ -50,9 +50,12 @@ type PolicyData struct {
 
 // Attributes contains the detals of allowed network policy type
 type Attributes struct {
-	AllowedNetwork string   `json:"allowed_network,omitempty"`
-	AllowedIP      []string `json:"allowed_ip, omitempty"`
+	AllowedNetwork string      `json:"allowed_network,omitempty"`
+	AllowedIP      IPAddresses `json:"allowed_ip,omitempty"`
 }
+
+// IPAddresses ...
+type IPAddresses []string
 
 // InstancePolicies represents a collection of Policies associated with Key Protect instances.
 type InstancePolicies struct {

--- a/instances.go
+++ b/instances.go
@@ -16,6 +16,7 @@ package kp
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"time"
 )
@@ -205,9 +206,17 @@ func (c *Client) SetAllowedIPInstancePolicy(ctx context.Context, enable bool, al
 			Enabled: &enable,
 		},
 	}
-	if enable && len(allowedIPs) > 0 {
-		policy.PolicyData.Attributes = &Attributes{}
-		policy.PolicyData.Attributes.AllowedIP = allowedIPs
+
+	// The IP address validation is performed by the key protect service.
+	if len(allowedIPs) != 0 {
+		if enable {
+			policy.PolicyData.Attributes = &Attributes{}
+			policy.PolicyData.Attributes.AllowedIP = allowedIPs
+		} else {
+			return fmt.Errorf("Provide IP Addresses only of the policy is being enabled")
+		}
+	} else {
+		return fmt.Errorf("Please provide atleast 1 IP Address")
 	}
 
 	policyRequest := InstancePolicies{
@@ -218,9 +227,6 @@ func (c *Client) SetAllowedIPInstancePolicy(ctx context.Context, enable bool, al
 		Policies: []InstancePolicy{policy},
 	}
 	err := c.setInstancePolicy(ctx, AllowedIP, policyRequest)
-	if err != nil {
-		return err
-	}
 
 	return err
 }

--- a/instances.go
+++ b/instances.go
@@ -100,7 +100,7 @@ func (c *Client) GetAllowedNetworkInstancePolicy(ctx context.Context) (*Instance
 
 // GetAllowedIPInstancePolicy retrieves the allowed IP instance policy details associated with the instance.
 // For more information can refer the Key Protect docs in the link below:
-//<KP Link>
+// https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-allowed-ip
 func (c *Client) GetAllowedIPInstancePolicy(ctx context.Context) (*InstancePolicy, error) {
 	policyResponse := InstancePolicies{}
 

--- a/instances.go
+++ b/instances.go
@@ -26,6 +26,9 @@ const (
 
 	//AllowedNetwork defines the policy type as allowed network
 	AllowedNetwork = "allowedNetwork"
+
+	//AllowedIP defines the polity type as allowed ip that are whitelisted
+	AllowedIP = "allowedIP"
 )
 
 // InstancePolicy represents a instance-level policy of a key as returned by the KP API.
@@ -47,7 +50,8 @@ type PolicyData struct {
 
 // Attributes contains the detals of allowed network policy type
 type Attributes struct {
-	AllowedNetwork string `json:"allowed_network,omitempty"`
+	AllowedNetwork string   `json:"allowed_network,omitempty"`
+	AllowedIP      []string `json:"allowed_ip, omitempty"`
 }
 
 // InstancePolicies represents a collection of Policies associated with Key Protect instances.
@@ -80,6 +84,24 @@ func (c *Client) GetAllowedNetworkInstancePolicy(ctx context.Context) (*Instance
 	policyResponse := InstancePolicies{}
 
 	err := c.getInstancePolicy(ctx, AllowedNetwork, &policyResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(policyResponse.Policies) == 0 {
+		return nil, nil
+	}
+
+	return &policyResponse.Policies[0], nil
+}
+
+// GetAllowedIPInstancePolicy retrieves the allowed IP instance policy details associated with the instance.
+// For more information can refer the Key Protect docs in the link below:
+//<KP Link>
+func (c *Client) GetAllowedIPInstancePolicy(ctx context.Context) (*InstancePolicy, error) {
+	policyResponse := InstancePolicies{}
+
+	err := c.getInstancePolicy(ctx, AllowedIP, &policyResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -163,6 +185,36 @@ func (c *Client) SetDualAuthInstancePolicy(ctx context.Context, enable bool) err
 	}
 
 	err := c.setInstancePolicy(ctx, DualAuthDelete, policyRequest)
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+// SetAllowedIPInstancePolices updates the allowed IP instance policy details associated with an instance.
+// For more information can refet to the Key Protect docs in the link below:
+// <KP link>
+func (c *Client) SetAllowedIPInstancePolicy(ctx context.Context, enable bool, allowedIPs []string) error {
+	policy := InstancePolicy{
+		PolicyType: AllowedIP,
+		PolicyData: PolicyData{
+			Enabled:    &enable,
+			Attributes: &Attributes{},
+		},
+	}
+	if len(allowedIPs) != 0 {
+		policy.PolicyData.Attributes.AllowedIP = allowedIPs
+	}
+
+	policyRequest := InstancePolicies{
+		Metadata: PoliciesMetadata{
+			CollectionType:   policyType,
+			NumberOfPolicies: 1,
+		},
+		Policies: []InstancePolicy{policy},
+	}
+	err := c.setInstancePolicy(ctx, AllowedIP, policyRequest)
 	if err != nil {
 		return err
 	}

--- a/kp_test.go
+++ b/kp_test.go
@@ -1641,7 +1641,7 @@ func TestSetAndGetInstancePolicies(t *testing.T) {
 			"policy_data": {
 				"enabled": true,
 				"attributes": {
-					"allowed_ip": ["47.220.195.239/32", "12.184.193.84/30"]
+					"allowed_ip": ["192.0.2.0/24", "203.0.113.0/32"]
 				}
 			}
 		}]
@@ -1652,7 +1652,7 @@ func TestSetAndGetInstancePolicies(t *testing.T) {
 		MatchParam("policy", "allowedIP").
 		Reply(204)
 
-	err = c.SetAllowedIPInstancePolicy(context.Background(), true, []string{"21.54.123.68/30", "53.114.213.84/32"})
+	err = c.SetAllowedIPInstancePolicy(context.Background(), true, []string{"192.0.2.0/24", "203.0.113.0/32"})
 
 	assert.NoError(t, err)
 

--- a/kp_test.go
+++ b/kp_test.go
@@ -1672,6 +1672,22 @@ func TestSetAndGetInstancePolicies(t *testing.T) {
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
 }
 
+// TestSetAllowedIPPolicyError tests the error scenarios while setting Allowed IP policy
+func TestSetAllowedIPPolicyError(t *testing.T) {
+	c, _, err := NewTestClient(t, nil)
+	c.tokenSource = &FakeTokenSource{}
+
+	err = c.SetAllowedIPInstancePolicy(context.Background(), false, []string{"192.0.2.0/24", "203.0.113.0/32"})
+
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "IP address list should only be provided if the policy is being enabled")
+
+	err = c.SetAllowedIPInstancePolicy(context.Background(), true, []string{})
+
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "Please provide atleast 1 IP subnet specified with CIDR notation")
+}
+
 //TestSetInstanceDualAuthPolicyError tests the methods set instance dual auth policy to error out with attributes field.
 func TestSetInstanceDualAuthPolicyError(t *testing.T) {
 	defer gock.Off()

--- a/kp_test.go
+++ b/kp_test.go
@@ -1680,12 +1680,12 @@ func TestSetAllowedIPPolicyError(t *testing.T) {
 	err = c.SetAllowedIPInstancePolicy(context.Background(), false, []string{"192.0.2.0/24", "203.0.113.0/32"})
 
 	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "IP address list should only be provided if the policy is being enabled")
+	assert.Equal(t, "IP address list should only be provided if the policy is being enabled", err.Error())
 
 	err = c.SetAllowedIPInstancePolicy(context.Background(), true, []string{})
 
 	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "Please provide atleast 1 IP subnet specified with CIDR notation")
+	assert.Equal(t, "Please provide at least 1 IP subnet specified with CIDR notation", err.Error())
 }
 
 //TestSetInstanceDualAuthPolicyError tests the methods set instance dual auth policy to error out with attributes field.


### PR DESCRIPTION
Associated with the issue: 154

Changes included in the PR: Adding support to create and get allowedIP instance policy for go sdk.