### PR TITLE
Updated methods to create and get KCIA instance policy

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -173,3 +173,46 @@ func ExampleClient_DeleteKey() {
 		fmt.Println("Deleted key: ", delKey)
 	}
 }
+
+func ExampleClient_InstancePolicies() {
+	client, _ := kp.New(
+		kp.ClientConfig{
+			BaseURL:    "https://us-south.kms.cloud.ibm.com",
+			APIKey:     "notARealApiKey",
+			InstanceID: "a6493c3a-5b29-4ac3-9eaa-deadbeef3bfd",
+		},
+		kp.DefaultTransport(),
+	)
+
+	policies := kp.MultiplePolicies {
+		DualAuthDelete : &kp.BasicPolicyData{
+			Enabled: true,
+		},
+		AllowedNetwork : &kp.AllowedNetworkPolicyData{
+			Enabled: true,
+			Network: "public-and-private",
+		},
+	}
+
+	fmt.Println("Creating instance policies")
+	err := client.SetInstancePolicies(context.Background(), policies)
+	if err != nil {
+		fmt.Println("Error while setting instance policies")
+	} else {
+		fmt.Println("Set instance polices")
+	}
+
+	attributes := map[string]bool{
+		"CreateRootKey": true,
+		"CreateStandardKey": true,
+	}
+	fmt.Println("Setting key create import access instance policy")
+	err = client.SetKeyCreateImportAccessInstancePolicy(context.Background(), true, attributes)
+	if err != nil {
+		fmt.Println("Error while setting key create import access instance policy")
+	} else {
+		fmt.Println("Set Key Create Import Access instance policy")
+	}
+
+
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.12
 require (
 	github.com/google/uuid v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.6.2
-	github.com/stretchr/testify v1.3.0
+	github.com/stretchr/testify v1.7.0
 	gopkg.in/h2non/gock.v1 v1.0.15
 )

--- a/instances.go
+++ b/instances.go
@@ -332,7 +332,7 @@ func (c *Client) SetMetricsInstancePolicy(ctx context.Context, enable bool) erro
 }
 
 // SetKeyCreateImportAccessInstancePolicy updates the key create import access policy details associated with an instance.
-// For more information can refer to the Key Protect docs in the link below:
+// For more information, please refer to the Key Protect docs in the link below:
 // https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-keyCreateImportAccess
 func (c *Client) SetKeyCreateImportAccessInstancePolicy(ctx context.Context, enable bool, attributes map[string]bool) error {
 	policy := InstancePolicy{
@@ -371,9 +371,6 @@ func (c *Client) SetKeyCreateImportAccessInstancePolicy(ctx context.Context, ena
 	}
 
 	err := c.setInstancePolicy(ctx, KeyCreateImportAccess, policyRequest)
-	if err != nil {
-		return err
-	}
 
 	return err
 }
@@ -430,7 +427,7 @@ func (c *Client) SetInstancePolicies(ctx context.Context, policies MultiplePolic
 
 	if policies.AllowedNetwork != nil {
 		policy := InstancePolicy{
-			PolicyType: "allowedNetwork",
+			PolicyType: AllowedNetwork,
 			PolicyData: PolicyData{
 				Enabled: &(policies.AllowedNetwork.Enabled),
 				Attributes: &Attributes{

--- a/instances.go
+++ b/instances.go
@@ -63,7 +63,7 @@ type PolicyData struct {
 
 // Attributes contains the detals of allowed network policy type
 type Attributes struct {
-	AllowedNetwork    string      `json:"allowed_network,omitempty"`
+	AllowedNetwork    *string     `json:"allowed_network,omitempty"`
 	AllowedIP         IPAddresses `json:"allowed_ip,omitempty"`
 	CreateRootKey     *bool       `json:"create_root_key,omitempty"`
 	CreateStandardKey *bool       `json:"create_standard_key,omitempty"`
@@ -136,7 +136,7 @@ func (c *Client) GetAllowedIPInstancePolicy(ctx context.Context) (*InstancePolic
 
 // GetKeyAccessInstancePolicy retrieves the key create import access policy details associated with the instance.
 // For more information can refer the Key Protect docs in the link below:
-// <kp link>
+// https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-key-creation-import
 func (c *Client) GetKeyAccessInstancePolicy(ctx context.Context) (*InstancePolicy, error) {
 	policyResponse := InstancePolicies{}
 
@@ -293,7 +293,7 @@ func (c *Client) SetAllowedNetworkInstancePolicy(ctx context.Context, enable boo
 		},
 	}
 	if networkType != "" {
-		policy.PolicyData.Attributes.AllowedNetwork = networkType
+		policy.PolicyData.Attributes.AllowedNetwork = &networkType
 	}
 
 	policyRequest := InstancePolicies{
@@ -341,8 +341,8 @@ func (c *Client) SetMetricsInstancePolicy(ctx context.Context, enable bool) erro
 
 // SetKeyAccessInstancePolicy updates the key create import access policy details associated with an instance.
 // For more information can refer to the Key Protect docs in the link below:
-// <kp link>
-func (c *Client) SetKeyAccessInstancePolicy(ctx context.Context, enable bool, attributes map[string]bool) error {
+// https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-key-creation-import
+func (c *Client) SetKeyAccessInstancePolicy(ctx context.Context, enable bool, attributes *Attributes) error {
 	policy := InstancePolicy{
 		PolicyType: KeyAccess,
 		PolicyData: PolicyData{
@@ -350,15 +350,7 @@ func (c *Client) SetKeyAccessInstancePolicy(ctx context.Context, enable bool, at
 		},
 	}
 
-	if enable {
-		policy.PolicyData.Attributes = &Attributes{}
-		a := policy.PolicyData.Attributes
-		a.CreateRootKey = validateValue(attributes, CreateRootKey)
-		a.CreateStandardKey = validateValue(attributes, CreateStandardKey)
-		a.ImportRootKey = validateValue(attributes, ImportRootKey)
-		a.ImportStandardKey = validateValue(attributes, ImportStandardKey)
-		a.EnforceToken = validateValue(attributes, EnforceToken)
-	}
+	policy.PolicyData.Attributes = attributes
 
 	policyRequest := InstancePolicies{
 		Metadata: PoliciesMetadata{

--- a/instances.go
+++ b/instances.go
@@ -51,8 +51,8 @@ type InstancePolicy struct {
 	CreatedAt  *time.Time `json:"creationDate,omitempty"`
 	UpdatedAt  *time.Time `json:"lastUpdated,omitempty"`
 	UpdatedBy  string     `json:"updatedBy,omitempty"`
-	PolicyType string     `json:"policy_type,omitempty"`
-	PolicyData PolicyData `json:"policy_data,omitempty" mapstructure:"policyData"`
+	PolicyType string     `json:"policyType,omitempty"`
+	PolicyData PolicyData `json:"policyData,omitempty" mapstructure:"policyData"`
 }
 
 // PolicyData contains the details of the policy type
@@ -63,13 +63,13 @@ type PolicyData struct {
 
 // Attributes contains the detals of allowed network policy type
 type Attributes struct {
-	AllowedNetwork    *string     `json:"allowed_network,omitempty"`
-	AllowedIP         IPAddresses `json:"allowed_ip,omitempty"`
-	CreateRootKey     *bool       `json:"create_root_key,omitempty"`
-	CreateStandardKey *bool       `json:"create_standard_key,omitempty"`
-	ImportRootKey     *bool       `json:"import_root_key,omitempty"`
-	ImportStandardKey *bool       `json:"import_standard_key,omitempty"`
-	EnforceToken      *bool       `json:"enforce_token,omitempty"`
+	AllowedNetwork    *string     `json:"allowedNetwork,omitempty"`
+	AllowedIP         IPAddresses `json:"allowedIP,omitempty"`
+	CreateRootKey     *bool       `json:"createRootKey,omitempty"`
+	CreateStandardKey *bool       `json:"createStandardKey,omitempty"`
+	ImportRootKey     *bool       `json:"importRootKey,omitempty"`
+	ImportStandardKey *bool       `json:"importStandardKey,omitempty"`
+	EnforceToken      *bool       `json:"enforceToken,omitempty"`
 }
 
 // IPAddresses ...
@@ -136,7 +136,7 @@ func (c *Client) GetAllowedIPInstancePolicy(ctx context.Context) (*InstancePolic
 
 // GetKeyAccessInstancePolicy retrieves the key create import access policy details associated with the instance.
 // For more information can refer the Key Protect docs in the link below:
-// https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-key-creation-import
+// https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-keyCreateImportAccess
 func (c *Client) GetKeyAccessInstancePolicy(ctx context.Context) (*InstancePolicy, error) {
 	policyResponse := InstancePolicies{}
 
@@ -341,7 +341,7 @@ func (c *Client) SetMetricsInstancePolicy(ctx context.Context, enable bool) erro
 
 // SetKeyAccessInstancePolicy updates the key create import access policy details associated with an instance.
 // For more information can refer to the Key Protect docs in the link below:
-// https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-key-creation-import
+// https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-keyCreateImportAccess
 func (c *Client) SetKeyAccessInstancePolicy(ctx context.Context, enable bool, attributes *Attributes) error {
 	policy := InstancePolicy{
 		PolicyType: KeyAccess,

--- a/instances.go
+++ b/instances.go
@@ -21,6 +21,7 @@ import (
 	"time"
 )
 
+<<<<<<< HEAD
 const (
 	// DualAuthDelete defines the policy type as dual auth delete
 	DualAuthDelete = "dualAuthDelete"
@@ -44,6 +45,8 @@ const (
 	EnforceToken      = "EnforceToken"
 )
 
+=======
+>>>>>>> Updated some requested changes
 // InstancePolicy represents a instance-level policy of a key as returned by the KP API.
 // this policy enables dual authorization for deleting a key
 type InstancePolicy struct {
@@ -51,8 +54,8 @@ type InstancePolicy struct {
 	CreatedAt  *time.Time `json:"creationDate,omitempty"`
 	UpdatedAt  *time.Time `json:"lastUpdated,omitempty"`
 	UpdatedBy  string     `json:"updatedBy,omitempty"`
-	PolicyType string     `json:"policyType,omitempty"`
-	PolicyData PolicyData `json:"policyData,omitempty" mapstructure:"policyData"`
+	PolicyType string     `json:"policy_type,omitempty"`
+	PolicyData PolicyData `json:"policy_data,omitempty" mapstructure:"policyData"`
 }
 
 // PolicyData contains the details of the policy type
@@ -63,13 +66,13 @@ type PolicyData struct {
 
 // Attributes contains the detals of allowed network policy type
 type Attributes struct {
-	AllowedNetwork    *string     `json:"allowedNetwork,omitempty"`
-	AllowedIP         IPAddresses `json:"allowedIP,omitempty"`
-	CreateRootKey     *bool       `json:"createRootKey,omitempty"`
-	CreateStandardKey *bool       `json:"createStandardKey,omitempty"`
-	ImportRootKey     *bool       `json:"importRootKey,omitempty"`
-	ImportStandardKey *bool       `json:"importStandardKey,omitempty"`
-	EnforceToken      *bool       `json:"enforceToken,omitempty"`
+	AllowedNetwork    *string     `json:"allowed_network,omitempty"`
+	AllowedIP         IPAddresses `json:"allowed_ip,omitempty"`
+	CreateRootKey     *bool       `json:"create_root_key,omitempty"`
+	CreateStandardKey *bool       `json:"create_standard_key,omitempty"`
+	ImportRootKey     *bool       `json:"import_root_key,omitempty"`
+	ImportStandardKey *bool       `json:"import_standard_key,omitempty"`
+	EnforceToken      *bool       `json:"enforce_token,omitempty"`
 }
 
 // IPAddresses ...
@@ -87,7 +90,7 @@ type InstancePolicies struct {
 func (c *Client) GetDualAuthInstancePolicy(ctx context.Context) (*InstancePolicy, error) {
 	policyResponse := InstancePolicies{}
 
-	err := c.getInstancePolicy(ctx, DualAuthDelete, &policyResponse)
+	err := c.getInstancePolicy(ctx, "dualAuthDelete", &policyResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +107,7 @@ func (c *Client) GetDualAuthInstancePolicy(ctx context.Context) (*InstancePolicy
 func (c *Client) GetAllowedNetworkInstancePolicy(ctx context.Context) (*InstancePolicy, error) {
 	policyResponse := InstancePolicies{}
 
-	err := c.getInstancePolicy(ctx, AllowedNetwork, &policyResponse)
+	err := c.getInstancePolicy(ctx, "allowedNetwork", &policyResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +125,7 @@ func (c *Client) GetAllowedNetworkInstancePolicy(ctx context.Context) (*Instance
 func (c *Client) GetAllowedIPInstancePolicy(ctx context.Context) (*InstancePolicy, error) {
 	policyResponse := InstancePolicies{}
 
-	err := c.getInstancePolicy(ctx, AllowedIP, &policyResponse)
+	err := c.getInstancePolicy(ctx, "allowedIP", &policyResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -135,12 +138,12 @@ func (c *Client) GetAllowedIPInstancePolicy(ctx context.Context) (*InstancePolic
 }
 
 // GetKeyAccessInstancePolicy retrieves the key create import access policy details associated with the instance.
-// For more information can refer the Key Protect docs in the link below:
+// For more information, Please refer the Key Protect docs in the link below:
 // https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-keyCreateImportAccess
 func (c *Client) GetKeyAccessInstancePolicy(ctx context.Context) (*InstancePolicy, error) {
 	policyResponse := InstancePolicies{}
 
-	err := c.getInstancePolicy(ctx, KeyAccess, &policyResponse)
+	err := c.getInstancePolicy(ctx, "keyCreateImportAccess", &policyResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -163,9 +166,7 @@ func (c *Client) getInstancePolicy(ctx context.Context, policyType string, polic
 	req.URL.RawQuery = v.Encode()
 
 	_, err = c.do(ctx, req, &policyResponse)
-	if err != nil {
-		return err
-	}
+
 	return err
 }
 
@@ -215,9 +216,7 @@ func (c *Client) setInstancePolicy(ctx context.Context, policyType string, polic
 
 	policiesResponse := InstancePolicies{}
 	_, err = c.do(ctx, req, &policiesResponse)
-	if err != nil {
-		return err
-	}
+
 	return err
 }
 
@@ -226,7 +225,7 @@ func (c *Client) setInstancePolicy(ctx context.Context, policyType string, polic
 // https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-dual-auth
 func (c *Client) SetDualAuthInstancePolicy(ctx context.Context, enable bool) error {
 	policy := InstancePolicy{
-		PolicyType: DualAuthDelete,
+		PolicyType: "dualAuthDelete",
 		PolicyData: PolicyData{
 			Enabled: &enable,
 		},
@@ -240,10 +239,7 @@ func (c *Client) SetDualAuthInstancePolicy(ctx context.Context, enable bool) err
 		Policies: []InstancePolicy{policy},
 	}
 
-	err := c.setInstancePolicy(ctx, DualAuthDelete, policyRequest)
-	if err != nil {
-		return err
-	}
+	err := c.setInstancePolicy(ctx, "dualAuthDelete", policyRequest)
 
 	return err
 }
@@ -252,8 +248,9 @@ func (c *Client) SetDualAuthInstancePolicy(ctx context.Context, enable bool) err
 // For more information can refet to the Key Protect docs in the link below:
 // https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-allowed-ip
 func (c *Client) SetAllowedIPInstancePolicy(ctx context.Context, enable bool, allowedIPs []string) error {
+
 	policy := InstancePolicy{
-		PolicyType: AllowedIP,
+		PolicyType: "allowedIP",
 		PolicyData: PolicyData{
 			Enabled: &enable,
 		},
@@ -276,7 +273,7 @@ func (c *Client) SetAllowedIPInstancePolicy(ctx context.Context, enable bool, al
 		},
 		Policies: []InstancePolicy{policy},
 	}
-	err := c.setInstancePolicy(ctx, AllowedIP, policyRequest)
+	err := c.setInstancePolicy(ctx, "allowedIP", policyRequest)
 
 	return err
 }
@@ -286,7 +283,7 @@ func (c *Client) SetAllowedIPInstancePolicy(ctx context.Context, enable bool, al
 // https://cloud.ibm.com/docs/key-protect?topic=key-protect-managing-network-access-policies
 func (c *Client) SetAllowedNetworkInstancePolicy(ctx context.Context, enable bool, networkType string) error {
 	policy := InstancePolicy{
-		PolicyType: AllowedNetwork,
+		PolicyType: "allowedNetwork",
 		PolicyData: PolicyData{
 			Enabled:    &enable,
 			Attributes: &Attributes{},
@@ -304,10 +301,7 @@ func (c *Client) SetAllowedNetworkInstancePolicy(ctx context.Context, enable boo
 		Policies: []InstancePolicy{policy},
 	}
 
-	err := c.setInstancePolicy(ctx, AllowedNetwork, policyRequest)
-	if err != nil {
-		return err
-	}
+	err := c.setInstancePolicy(ctx, "allowedNetwork", policyRequest)
 
 	return err
 }
@@ -340,11 +334,19 @@ func (c *Client) SetMetricsInstancePolicy(ctx context.Context, enable bool) erro
 }
 
 // SetKeyAccessInstancePolicy updates the key create import access policy details associated with an instance.
-// For more information can refer to the Key Protect docs in the link below:
+// For more information, please refer to the Key Protect docs in the link below:
 // https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-keyCreateImportAccess
-func (c *Client) SetKeyAccessInstancePolicy(ctx context.Context, enable bool, attributes *Attributes) error {
+func (c *Client) SetKeyAccessInstancePolicy(ctx context.Context, attributes *Attributes) error {
+	var enable bool
+
+	if attributes == nil {
+		enable = false
+	} else {
+		enable = true
+	}
+
 	policy := InstancePolicy{
-		PolicyType: KeyAccess,
+		PolicyType: "keyCreateImportAccess",
 		PolicyData: PolicyData{
 			Enabled: &enable,
 		},
@@ -360,10 +362,7 @@ func (c *Client) SetKeyAccessInstancePolicy(ctx context.Context, enable bool, at
 		Policies: []InstancePolicy{policy},
 	}
 
-	err := c.setInstancePolicy(ctx, KeyAccess, policyRequest)
-	if err != nil {
-		return err
-	}
+	err := c.setInstancePolicy(ctx, "keyCreateImportAccess", policyRequest)
 
 	return err
 }
@@ -409,7 +408,7 @@ func (c *Client) SetInstancePolicies(ctx context.Context, policies MultiplePolic
 
 	if policies.AllowedNetwork != nil {
 		policy := InstancePolicy{
-			PolicyType: AllowedNetwork,
+			PolicyType: "allowedNetwork",
 			PolicyData: PolicyData{
 				Enabled: &(policies.AllowedNetwork.Enabled),
 				Attributes: &Attributes{
@@ -459,11 +458,8 @@ func (c *Client) SetInstancePolicies(ctx context.Context, policies MultiplePolic
 	}
 
 	_, err = c.do(ctx, req, &policyresponse)
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return err
 }
 
 type portsMetadata struct {

--- a/instances.go
+++ b/instances.go
@@ -88,7 +88,7 @@ type InstancePolicies struct {
 func (c *Client) GetDualAuthInstancePolicy(ctx context.Context) (*InstancePolicy, error) {
 	policyResponse := InstancePolicies{}
 
-	err := c.getInstancePolicy(ctx, "dualAuthDelete", &policyResponse)
+	err := c.getInstancePolicy(ctx, DualAuthDelete, &policyResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (c *Client) GetDualAuthInstancePolicy(ctx context.Context) (*InstancePolicy
 func (c *Client) GetAllowedNetworkInstancePolicy(ctx context.Context) (*InstancePolicy, error) {
 	policyResponse := InstancePolicies{}
 
-	err := c.getInstancePolicy(ctx, "allowedNetwork", &policyResponse)
+	err := c.getInstancePolicy(ctx, AllowedNetwork, &policyResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func (c *Client) GetAllowedNetworkInstancePolicy(ctx context.Context) (*Instance
 func (c *Client) GetAllowedIPInstancePolicy(ctx context.Context) (*InstancePolicy, error) {
 	policyResponse := InstancePolicies{}
 
-	err := c.getInstancePolicy(ctx, "allowedIP", &policyResponse)
+	err := c.getInstancePolicy(ctx, AllowedIP, &policyResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +223,7 @@ func (c *Client) setInstancePolicy(ctx context.Context, policyType string, polic
 // https://cloud.ibm.com/docs/key-protect?topic=key-protect-manage-dual-auth
 func (c *Client) SetDualAuthInstancePolicy(ctx context.Context, enable bool) error {
 	policy := InstancePolicy{
-		PolicyType: "dualAuthDelete",
+		PolicyType: DualAuthDelete,
 		PolicyData: PolicyData{
 			Enabled: &enable,
 		},
@@ -237,7 +237,7 @@ func (c *Client) SetDualAuthInstancePolicy(ctx context.Context, enable bool) err
 		Policies: []InstancePolicy{policy},
 	}
 
-	err := c.setInstancePolicy(ctx, "dualAuthDelete", policyRequest)
+	err := c.setInstancePolicy(ctx, DualAuthDelete, policyRequest)
 
 	return err
 }
@@ -248,7 +248,7 @@ func (c *Client) SetDualAuthInstancePolicy(ctx context.Context, enable bool) err
 func (c *Client) SetAllowedIPInstancePolicy(ctx context.Context, enable bool, allowedIPs []string) error {
 
 	policy := InstancePolicy{
-		PolicyType: "allowedIP",
+		PolicyType: AllowedIP,
 		PolicyData: PolicyData{
 			Enabled: &enable,
 		},
@@ -271,7 +271,7 @@ func (c *Client) SetAllowedIPInstancePolicy(ctx context.Context, enable bool, al
 		},
 		Policies: []InstancePolicy{policy},
 	}
-	err := c.setInstancePolicy(ctx, "allowedIP", policyRequest)
+	err := c.setInstancePolicy(ctx, AllowedIP, policyRequest)
 
 	return err
 }
@@ -281,7 +281,7 @@ func (c *Client) SetAllowedIPInstancePolicy(ctx context.Context, enable bool, al
 // https://cloud.ibm.com/docs/key-protect?topic=key-protect-managing-network-access-policies
 func (c *Client) SetAllowedNetworkInstancePolicy(ctx context.Context, enable bool, networkType string) error {
 	policy := InstancePolicy{
-		PolicyType: "allowedNetwork",
+		PolicyType: AllowedNetwork,
 		PolicyData: PolicyData{
 			Enabled:    &enable,
 			Attributes: &Attributes{},
@@ -299,7 +299,7 @@ func (c *Client) SetAllowedNetworkInstancePolicy(ctx context.Context, enable boo
 		Policies: []InstancePolicy{policy},
 	}
 
-	err := c.setInstancePolicy(ctx, "allowedNetwork", policyRequest)
+	err := c.setInstancePolicy(ctx, AllowedNetwork, policyRequest)
 
 	return err
 }

--- a/kp_test.go
+++ b/kp_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/IBM/keyprotect-go-client/iam"
 	"github.com/google/uuid"
 
-	"github.com/stretchr/stew/slice"
 	"github.com/stretchr/testify/assert"
 	gock "gopkg.in/h2non/gock.v1"
 )
@@ -2454,20 +2453,12 @@ func TestGetKeyWithAlias(t *testing.T) {
 	defer gock.RestoreClient(&c.HttpClient)
 	c.tokenSource = &FakeTokenSource{}
 
-<<<<<<< HEAD
 	key, err := c.GetKey(context.Background(), alias)
-=======
-	key, err := c.GetKeyByAlias(context.Background(), alias)
->>>>>>> Added methods to create, delete key alias and get key and key metadate by alias
 
 	assert.NoError(t, err)
 	assert.NotNil(t, key)
 	assert.NotEqual(t, key.Payload, "")
-<<<<<<< HEAD
 	assert.Contains(t, key.Aliases, alias)
-=======
-	assert.True(t, slice.ContainsString(key.Aliases, alias))
->>>>>>> Added methods to create, delete key alias and get key and key metadate by alias
 
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called")
 }

--- a/kp_test.go
+++ b/kp_test.go
@@ -1676,7 +1676,7 @@ func TestSetAndGetDualAuthInstancePolicy(t *testing.T) {
 		Put("/instance/policies").
 		// MatchType("json").
 		// JSON(dualAuthPolicyRequest).
-		MatchParam("policy", "dualAuthDelete").
+		MatchParam("policy", DualAuthDelete).
 		Reply(204)
 
 	err = c.SetDualAuthInstancePolicy(context.Background(), false)
@@ -1685,7 +1685,7 @@ func TestSetAndGetDualAuthInstancePolicy(t *testing.T) {
 
 	gock.New("http://example.com").
 		Get("/instance/policies").
-		MatchParam("policy", "dualAuthDelete").
+		MatchParam("policy", DualAuthDelete).
 		Reply(200).
 		Body(bytes.NewReader(dualAuthPolicyResponse))
 
@@ -1693,7 +1693,7 @@ func TestSetAndGetDualAuthInstancePolicy(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, dap)
-	assert.Equal(t, dap.PolicyType, "dualAuthDelete")
+	assert.Equal(t, dap.PolicyType, DualAuthDelete)
 	assert.True(t, *(dap.PolicyData.Enabled))
 
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
@@ -1752,7 +1752,7 @@ func TestSetAndGetAllowedNetworkPolicy(t *testing.T) {
 		Put("/instance/policies").
 		// MatchType("json").
 		// JSON(allowedNetworkPolicyRequest).
-		MatchParam("policy", "allowedNetwork").
+		MatchParam("policy", AllowedNetwork).
 		Reply(204)
 
 	err = c.SetAllowedNetworkInstancePolicy(context.Background(), true, "public-and-private")
@@ -1761,7 +1761,7 @@ func TestSetAndGetAllowedNetworkPolicy(t *testing.T) {
 
 	gock.New("http://example.com").
 		Get("/instance/policies").
-		MatchParam("policy", "allowedNetwork").
+		MatchParam("policy", AllowedNetwork).
 		Reply(200).
 		Body(bytes.NewReader(allowedNetworkPolicyResponse))
 
@@ -1769,7 +1769,7 @@ func TestSetAndGetAllowedNetworkPolicy(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, ap)
-	assert.Equal(t, ap.PolicyType, "allowedNetwork")
+	assert.Equal(t, ap.PolicyType, AllowedNetwork)
 	assert.True(t, *(ap.PolicyData.Enabled))
 	assert.Equal(t, *(ap.PolicyData.Attributes.AllowedNetwork), "public-and-private")
 
@@ -1863,7 +1863,7 @@ func TestSetAndGetAllowedIPInstancePolicy(t *testing.T) {
 		Put("/api/v2/instance/policies").
 		// MatchType("json").
 		// JSON(allowedIPPolicyEnableRequest).
-		MatchParam("policy", "allowedIP").
+		MatchParam("policy", AllowedIP).
 		Reply(204)
 
 	err = c.SetAllowedIPInstancePolicy(context.Background(), true, []string{"192.0.2.0/24", "203.0.113.0/32"})
@@ -1872,7 +1872,7 @@ func TestSetAndGetAllowedIPInstancePolicy(t *testing.T) {
 
 	gock.New("http://example.com").
 		Get("/api/v2/instance/policies").
-		MatchParam("policy", "allowedIP").
+		MatchParam("policy", AllowedIP).
 		Reply(200).
 		Body(bytes.NewReader(allowedIPPolicyEnabledResponse))
 
@@ -1880,14 +1880,14 @@ func TestSetAndGetAllowedIPInstancePolicy(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, ip)
-	assert.Equal(t, ip.PolicyType, "allowedIP")
+	assert.Equal(t, ip.PolicyType, AllowedIP)
 	assert.True(t, *(ip.PolicyData.Enabled))
 
 	gock.New("http://example/com").
 		Put("/api/v2/instance/policies").
 		// MatchType("json").
 		// JSON(allowedIPPolicyDisableRequest).
-		MatchParam("policy", "allowedIP").
+		MatchParam("policy", AllowedIP).
 		Reply(204)
 
 	err = c.SetAllowedIPInstancePolicy(context.Background(), false, []string{})
@@ -1896,7 +1896,7 @@ func TestSetAndGetAllowedIPInstancePolicy(t *testing.T) {
 
 	gock.New("http://example.com").
 		Get("/api/v2/instance/policies").
-		MatchParam("policy", "allowedIP").
+		MatchParam("policy", AllowedIP).
 		Reply(200).
 		Body(bytes.NewReader(allowedIPPolicyDisabledResponse))
 
@@ -1904,7 +1904,7 @@ func TestSetAndGetAllowedIPInstancePolicy(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, ip)
-	assert.Equal(t, ip.PolicyType, "allowedIP")
+	assert.Equal(t, ip.PolicyType, AllowedIP)
 	assert.False(t, *(ip.PolicyData.Enabled))
 
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
@@ -2006,7 +2006,7 @@ func TestSetAndGetKeyCreateImportAccessInstancePolicy(t *testing.T) {
 		Put("/instance/policies").
 		// MatchType("json").
 		// JSON(keyAccessEnableRequest).
-		MatchParam("policy", "keyCreateImportAccess").
+		MatchParam("policy", KeyCreateImportAccess).
 		Reply(204)
 
 	attributes := map[string]bool {
@@ -2021,7 +2021,7 @@ func TestSetAndGetKeyCreateImportAccessInstancePolicy(t *testing.T) {
 
 	gock.New("http://example.com").
 		Get("/instance/policies").
-		MatchParam("policy", "keyCreateImportAccess").
+		MatchParam("policy", KeyCreateImportAccess).
 		Reply(200).
 		Body(bytes.NewReader(keyAccessEnabledResponse))
 
@@ -2029,7 +2029,7 @@ func TestSetAndGetKeyCreateImportAccessInstancePolicy(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, kip)
-	assert.Equal(t, kip.PolicyType, "keyCreateImportAccess")
+	assert.Equal(t, kip.PolicyType, KeyCreateImportAccess)
 	assert.True(t, *(kip.PolicyData.Enabled))
 	assert.True(t, *(kip.PolicyData.Attributes.CreateRootKey))
 	assert.False(t, *(kip.PolicyData.Attributes.CreateStandardKey))
@@ -2041,7 +2041,7 @@ func TestSetAndGetKeyCreateImportAccessInstancePolicy(t *testing.T) {
 		Put("/instance/policies").
 		// MatchType("json").
 		// JSON(keyAccessDisableRequest).
-		MatchParam("policy", "keyCreateImportAccess").
+		MatchParam("policy", KeyCreateImportAccess).
 		Reply(204)
 
 	err = c.SetKeyCreateImportAccessInstancePolicy(context.Background(), false, nil)
@@ -2050,7 +2050,7 @@ func TestSetAndGetKeyCreateImportAccessInstancePolicy(t *testing.T) {
 
 	gock.New("http://example.com").
 		Get("/instance/policies").
-		MatchParam("policy", "keyCreateImportAccess").
+		MatchParam("policy", KeyCreateImportAccess).
 		Reply(200).
 		Body(bytes.NewReader(keyAccessDisabledResponse))
 
@@ -2058,7 +2058,7 @@ func TestSetAndGetKeyCreateImportAccessInstancePolicy(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, kip)
-	assert.Equal(t, kip.PolicyType, "keyCreateImportAccess")
+	assert.Equal(t, kip.PolicyType, KeyCreateImportAccess)
 	assert.False(t, *(kip.PolicyData.Enabled))
 
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
@@ -2109,7 +2109,7 @@ func TestSetMetricsPolicy(t *testing.T) {
 		Put("/instance/policies").
 		// MatchType("json").
 		// JSON(metricsPolicyRequest).
-		MatchParam("policy", "metrics").
+		MatchParam("policy", Metrics).
 		Reply(204)
 
 	err = c.SetMetricsInstancePolicy(context.Background(), true)
@@ -2118,7 +2118,7 @@ func TestSetMetricsPolicy(t *testing.T) {
 
 	gock.New("http://example.com").
 		Get("/instance/policies").
-		MatchParam("policy", "metrics").
+		MatchParam("policy", Metrics).
 		Reply(200).
 		Body(bytes.NewReader(metricsPolicyResponse))
 
@@ -2221,7 +2221,7 @@ func TestSetInstanceDualAuthPolicyError(t *testing.T) {
 
 	gock.New("http://example.com").
 		Put("/api/v2/instance/policies").
-		MatchParam("policy", "dualAuthDelete").
+		MatchParam("policy", DualAuthDelete).
 		Reply(400).
 		Body(bytes.NewReader(errorResponse))
 
@@ -2316,7 +2316,7 @@ func TestSetKeyPolicies(t *testing.T) {
 
 	gock.New("http://example.com").
 		Put("/api/v2/keys/"+testKey+"/policies").
-		MatchParam("policy", "dualAuthDelete").
+		MatchParam("policy", DualAuthDelete).
 		Reply(200).Body(bytes.NewReader(dualAuthPolicyResponse))
 
 	c, _, err := NewTestClient(t, nil)
@@ -2465,7 +2465,7 @@ func TestGetKeyPolicies(t *testing.T) {
 
 	gock.New("http://example.com").
 		Get("/api/v2/keys/"+testKey+"/policies").
-		MatchParam("policy", "dualAuthDelete").
+		MatchParam("policy", DualAuthDelete).
 		Reply(200).Body(bytes.NewReader(dualAuthPolicyResponse))
 
 	dualAuthPolicy, err := c.GetDualAuthDeletePolicy(context.Background(), testKey)

--- a/kp_test.go
+++ b/kp_test.go
@@ -1523,7 +1523,7 @@ func TestRestoreKey(t *testing.T) {
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
 }
 
-// TestSetAndGetMultipleInstancePolicies tests the methods that update and retrieve mutliple instance policies
+// TestSetAndGetMultipleInstancePolicies tests the methods that update and retrieve multiple instance policies
 func TestSetAndGetMultipleInstancePolicies(t *testing.T) {
 	defer gock.Off()
 

--- a/kp_test.go
+++ b/kp_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/IBM/keyprotect-go-client/iam"
 	"github.com/google/uuid"
 
+	"github.com/stretchr/stew/slice"
 	"github.com/stretchr/testify/assert"
 	gock "gopkg.in/h2non/gock.v1"
 )
@@ -2453,12 +2454,20 @@ func TestGetKeyWithAlias(t *testing.T) {
 	defer gock.RestoreClient(&c.HttpClient)
 	c.tokenSource = &FakeTokenSource{}
 
+<<<<<<< HEAD
 	key, err := c.GetKey(context.Background(), alias)
+=======
+	key, err := c.GetKeyByAlias(context.Background(), alias)
+>>>>>>> Added methods to create, delete key alias and get key and key metadate by alias
 
 	assert.NoError(t, err)
 	assert.NotNil(t, key)
 	assert.NotEqual(t, key.Payload, "")
+<<<<<<< HEAD
 	assert.Contains(t, key.Aliases, alias)
+=======
+	assert.True(t, slice.ContainsString(key.Aliases, alias))
+>>>>>>> Added methods to create, delete key alias and get key and key metadate by alias
 
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called")
 }

--- a/policy.go
+++ b/policy.go
@@ -40,7 +40,7 @@ type Policy struct {
 }
 
 type Rotation struct {
-	Interval int `json:"interval_month,omitempty"`
+	Interval int `json:"intervalMonth,omitempty"`
 }
 
 type DualAuth struct {

--- a/policy.go
+++ b/policy.go
@@ -176,7 +176,7 @@ func (c *Client) GetRotationPolicy(ctx context.Context, id string) (*Policy, err
 func (c *Client) GetDualAuthDeletePolicy(ctx context.Context, id string) (*Policy, error) {
 	policyresponse := Policies{}
 
-	err := c.getPolicy(ctx, id, "dualAuthDelete", &policyresponse)
+	err := c.getPolicy(ctx, id, DualAuthDelete, &policyresponse)
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +257,7 @@ func (c *Client) SetDualAuthDeletePolicy(ctx context.Context, id string, enabled
 		Policies: []Policy{policy},
 	}
 
-	policyresponse, err := c.setPolicy(ctx, id, "dualAuthDelete", policyRequest)
+	policyresponse, err := c.setPolicy(ctx, id, DualAuthDelete, policyRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/policy.go
+++ b/policy.go
@@ -40,7 +40,7 @@ type Policy struct {
 }
 
 type Rotation struct {
-	Interval int `json:"intervalMonth,omitempty"`
+	Interval int `json:"interval_month,omitempty"`
 }
 
 type DualAuth struct {
@@ -176,7 +176,7 @@ func (c *Client) GetRotationPolicy(ctx context.Context, id string) (*Policy, err
 func (c *Client) GetDualAuthDeletePolicy(ctx context.Context, id string) (*Policy, error) {
 	policyresponse := Policies{}
 
-	err := c.getPolicy(ctx, id, DualAuthDelete, &policyresponse)
+	err := c.getPolicy(ctx, id, "dualAuthDelete", &policyresponse)
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +257,7 @@ func (c *Client) SetDualAuthDeletePolicy(ctx context.Context, id string, enabled
 		Policies: []Policy{policy},
 	}
 
-	policyresponse, err := c.setPolicy(ctx, id, DualAuthDelete, policyRequest)
+	policyresponse, err := c.setPolicy(ctx, id, "dualAuthDelete", policyRequest)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Associated with the issue: 51

changes included in the PR: Added methods to create and get the key create import access instance policy