### PR TITLE
added method to retrieve private port number for allowed ip

### DIFF
--- a/instances.go
+++ b/instances.go
@@ -309,35 +309,35 @@ func (c *Client) SetInstancePolicies(ctx context.Context, setDualAuth, dualAuthE
 	return nil
 }
 
-type PortsMetadata struct {
+type portsMetadata struct {
 	CollectionType string `json:"collectionType"`
 	NumberOfPorts  int    `json:"collectionTotal"`
 }
 
-type Ports struct {
-	Metadata PortsMetadata `json:"metadata"`
-	Ports    []PrivatePort `json:"resources"`
+type portResponse struct {
+	Metadata portsMetadata `json:"metadata"`
+	Ports    []privatePort `json:"resources"`
 }
-type PrivatePort struct {
+type privatePort struct {
 	PrivatePort int `json:"private_endpoint_port,omitempty"`
 }
 
 // GetAllowedIPPrivateNetworkPort retrieves the private endpoint port assigned to allowed ip policy.
-func (c *Client) GetAllowedIPPrivateNetworkPort(ctx context.Context) (*PrivatePort, error) {
-	var portResponse Ports
+func (c *Client) GetAllowedIPPrivateNetworkPort(ctx context.Context) (int, error) {
+	var portResponse portResponse
 
 	req, err := c.newRequest("GET", "instance/allowed_ip_port", nil)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 
 	_, err = c.do(ctx, req, &portResponse)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 
 	if len(portResponse.Ports) == 0 {
-		return nil, fmt.Errorf("No port number available. Please check the instance has an enabled allowedIP policy")
+		return 0, fmt.Errorf("No port number available. Please check the instance has an enabled allowedIP policy")
 	}
-	return &portResponse.Ports[0], nil
+	return portResponse.Ports[0].PrivatePort, nil
 }

--- a/instances.go
+++ b/instances.go
@@ -308,3 +308,36 @@ func (c *Client) SetInstancePolicies(ctx context.Context, setDualAuth, dualAuthE
 
 	return nil
 }
+
+type PortsMetadata struct {
+	CollectionType string `json:"collectionType"`
+	NumberOfPorts  int    `json:"collectionTotal"`
+}
+
+type Ports struct {
+	Metadata PortsMetadata `json:"metadata"`
+	Ports    []PrivatePort `json:"resources"`
+}
+type PrivatePort struct {
+	PrivatePort int `json:"private_endpoint_port,omitempty"`
+}
+
+// GetAllowedIPPrivateNetworkPort retrieves the private endpoint port assigned to allowed ip policy.
+func (c *Client) GetAllowedIPPrivateNetworkPort(ctx context.Context) (*PrivatePort, error) {
+	var portResponse Ports
+
+	req, err := c.newRequest("GET", "instance/allowed_ip_port", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = c.do(ctx, req, &portResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(portResponse.Ports) == 0 {
+		return nil, fmt.Errorf("No port number available")
+	}
+	return &portResponse.Ports[0], nil
+}

--- a/instances.go
+++ b/instances.go
@@ -337,7 +337,7 @@ func (c *Client) GetAllowedIPPrivateNetworkPort(ctx context.Context) (*PrivatePo
 	}
 
 	if len(portResponse.Ports) == 0 {
-		return nil, fmt.Errorf("No port number available")
+		return nil, fmt.Errorf("No port number available. Please check the instance has an enabled allowedIP policy")
 	}
 	return &portResponse.Ports[0], nil
 }

--- a/kp_test.go
+++ b/kp_test.go
@@ -1689,6 +1689,7 @@ func TestSetAllowedIPPolicyError(t *testing.T) {
 
 }
 
+// TestGetPrivateEndpointPortNumber tests the method that retrieves the private endponint port number
 func TestGetPrivateEndpointPortNumber(t *testing.T) {
 	defer gock.Off()
 	response := []byte(`{
@@ -1714,8 +1715,26 @@ func TestGetPrivateEndpointPortNumber(t *testing.T) {
 	port, err := c.GetAllowedIPPrivateNetworkPort(context.Background())
 
 	assert.NoError(t, err)
-	assert.NotNil(t, port)
-	assert.Equal(t, port.PrivatePort, 15008)
+	assert.Equal(t, port, 15008)
+
+	// Error scenario
+	noPortResponse := []byte(`{
+		"metadata": {
+			"collectionType": "application/vnd.ibm.kms.allowed_ip_metadata+json",
+			"collectionTotal": 1
+		},
+		"resources": []
+	}`)
+
+	gock.New("http://example.com").
+		Get("instance/allowed_ip_port").
+		Reply(200).
+		Body(bytes.NewReader(noPortResponse))
+
+	port, err = c.GetAllowedIPPrivateNetworkPort(context.Background())
+
+	assert.Error(t, err)
+	assert.Equal(t, err.Error(), "No port number available. Please check the instance has an enabled allowedIP policy")
 
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called")
 }

--- a/kp_test.go
+++ b/kp_test.go
@@ -1689,7 +1689,7 @@ func TestSetAllowedIPPolicyError(t *testing.T) {
 
 }
 
-// TestGetPrivateEndpointPortNumber tests the method that retrieves the private endponint port number
+// TestGetPrivateEndpointPortNumber tests the method that retrieves the private endpoint port number
 func TestGetPrivateEndpointPortNumber(t *testing.T) {
 	defer gock.Off()
 	response := []byte(`{

--- a/kp_test.go
+++ b/kp_test.go
@@ -1686,6 +1686,38 @@ func TestSetAllowedIPPolicyError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Equal(t, "Please provide at least 1 IP subnet specified with CIDR notation", err.Error())
+
+}
+
+func TestGetPrivateEndpointPortNumber(t *testing.T) {
+	defer gock.Off()
+	response := []byte(`{
+		"metadata": {
+			"collectionType": "application/vnd.ibm.kms.allowed_ip_metadata+json",
+			"collectionTotal": 1
+		},
+		"resources": [{
+			"private_endpoint_port": 15008
+		}]
+	}`)
+
+	gock.New("http://example.com").
+		Get("instance/allowed_ip_port").
+		Reply(200).
+		Body(bytes.NewReader(response))
+
+	c, _, err := NewTestClient(t, nil)
+	gock.InterceptClient(&c.HttpClient)
+	defer gock.RestoreClient(&c.HttpClient)
+	c.tokenSource = &FakeTokenSource{}
+
+	port, err := c.GetAllowedIPPrivateNetworkPort(context.Background())
+
+	assert.NoError(t, err)
+	assert.NotNil(t, port)
+	assert.Equal(t, port.PrivatePort, 15008)
+
+	assert.True(t, gock.IsDone(), "Expected HTTP requests not called")
 }
 
 //TestSetInstanceDualAuthPolicyError tests the methods set instance dual auth policy to error out with attributes field.


### PR DESCRIPTION
Associated with the issue: 197

Changes included in the PR: Updated a method to retrieve private port number for allowed ip.