### PR TITLE
Fix nil deref on strange IAM error response

### DIFF
--- a/iam/iam.go
+++ b/iam/iam.go
@@ -236,6 +236,17 @@ type iamRequestContext struct {
 }
 
 func (ie Error) Error() string {
+
+	reqId := ""
+	if ie.Context != nil {
+		reqId = ie.Context.RequestID
+	}
+
+	statusCode := 0
+	if ie.HTTPResponse != nil {
+		statusCode = ie.HTTPResponse.StatusCode
+	}
+
 	return fmt.Sprintf("iam.Error: HTTP %d requestId='%s' message='%s %s'",
-		ie.HTTPResponse.StatusCode, ie.Context.RequestID, ie.ErrorCode, ie.ErrorMessage)
+		statusCode, reqId, ie.ErrorCode, ie.ErrorMessage)
 }

--- a/iam/iam_test.go
+++ b/iam/iam_test.go
@@ -120,3 +120,17 @@ func TestValid_NilToken_ReturnsFalse(t *testing.T) {
 	var tok *Token
 	assert.False(t, tok.Valid(), "tok.Valid() should return false")
 }
+
+func TestError_NilContextOrResp_NoNilDeref(t *testing.T) {
+
+	err := Error{
+		ErrorCode:    "TEST123",
+		ErrorMessage: "Test Error",
+		Context:      nil,
+		HTTPResponse: nil,
+	}
+
+	errStr := err.Error()
+
+	assert.Equal(t, errStr, "iam.Error: HTTP 0 requestId='' message='TEST123 Test Error'")
+}


### PR DESCRIPTION
Apparently IAM is sending back valid JSON without
a context object in some cases, and we don't check for
that being nil, which causes a nil deref issue sometimes.

Add code to check and handle, and a unit test.

Resolves: #45