### PR TITLE
Move to latest supported go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: go
 dist: xenial
 
 go: 
- - 1.13.x
- - 1.12.x
+ - 1.14.x
+ - 1.15.x
 
 env:
   - GO111MODULE=on

--- a/kp_test.go
+++ b/kp_test.go
@@ -176,7 +176,11 @@ func TestKeys(t *testing.T) {
 				c := NewTestClientConfig()
 				c.BaseURL = ":"
 				_, err = NewWithLogger(c, nil, l)
-				assert.EqualError(t, err, "parse :/api/v2/: missing protocol scheme")
+
+				// assert that we got a url.Error while parsing the bad BaseURL
+				assert.Error(t, err)
+				assert.IsType(t, &url.Error{}, err)
+				assert.Equal(t, err.(*url.Error).Op, "parse")
 
 				return nil
 			},


### PR DESCRIPTION
Go 1.14 is the minimum supported version currently, so fix Travis CI to test against that.

Resolves #43 