### PR TITLE
Updated the 201 status code check with no response body

### DIFF
--- a/kp.go
+++ b/kp.go
@@ -286,7 +286,13 @@ func (c *Client) do(ctx context.Context, req *http.Request, res interface{}) (*h
 	}
 
 	switch response.StatusCode {
-	case http.StatusOK, http.StatusCreated:
+	case http.StatusCreated:
+		if len(resBody) != 0 {
+			if err := json.Unmarshal(resBody, res); err != nil {
+				return nil, err
+			}
+		}
+	case http.StatusOK:
 		if err := json.Unmarshal(resBody, res); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
A quick fix to which key-ring create is failing the first attempt but succeeding the second time in CLI.
The create key ring response returns a 201 with no response body. The key ring create request with the same key ring id the second time returns a 204 which is returning success in CLI. 
Interestingly the SDK did not catch this problem. 