### PR TITLE
add Key patch request to transfer to new key ring

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -94,10 +94,6 @@ type KeyVersion struct {
 	CreationDate *time.Time `json:"creationDate,omitempty"`
 }
 
-type KeyRingID struct {
-	KeyRingID string `json:"keyRingID"`
-}
-
 // CreateKey creates a new KP key.
 func (c *Client) CreateKey(ctx context.Context, name string, expiration *time.Time, extractable bool) (*Key, error) {
 	return c.CreateImportedKey(ctx, name, expiration, "", "", "", extractable)
@@ -207,11 +203,21 @@ func (c *Client) createKey(ctx context.Context, key Key) (*Key, error) {
 	return &keysResponse.Keys[0], nil
 }
 
-// TransferKeyToNewKeyRing method transfers a key associated with one key ring to another key ring
+// SetKeyRing method transfers a key associated with one key ring to another key ring
 // For more information please refer to the link below:
 // https://cloud.ibm.com/docs/key-protect?topic=key-protect-grouping-keys#transfer-key-key-ring
-func (c *Client) TransferKeyToNewKeyRing(ctx context.Context, keyID, newKeyRingID string) (*Key, error) {
-	keyRingRequestBody := KeyRingID{
+func (c *Client) SetKeyRing(ctx context.Context, keyID, newKeyRingID string) (*Key, error) {
+	if keyID == "" {
+		return nil, fmt.Errorf("Please provide a valid key ID")
+	}
+
+	if newKeyRingID == "" {
+		return nil, fmt.Errorf("Please provide a valid key ring id")
+	}
+
+	keyRingRequestBody := struct {
+		KeyRingID string
+	}{
 		KeyRingID: newKeyRingID,
 	}
 

--- a/keys.go
+++ b/keys.go
@@ -55,7 +55,7 @@ type Key struct {
 	KeyRingID           string      `json:"keyRingID,omitempty"`
 	Extractable         bool        `json:"extractable"`
 	Expiration          *time.Time  `json:"expirationDate,omitempty"`
-	Imported            *bool       `json:"imported,omitempty"`
+	Imported            bool        `json:"imported,omitempty"`
 	Payload             string      `json:"payload,omitempty"`
 	State               int         `json:"state,omitempty"`
 	EncryptionAlgorithm string      `json:"encryptionAlgorithm,omitempty"`

--- a/keys.go
+++ b/keys.go
@@ -55,11 +55,7 @@ type Key struct {
 	KeyRingID           string      `json:"keyRingID,omitempty"`
 	Extractable         bool        `json:"extractable"`
 	Expiration          *time.Time  `json:"expirationDate,omitempty"`
-<<<<<<< HEAD
 	Imported            *bool       `json:"imported,omitempty"`
-=======
-	Imported            bool        `json:"imported,omitempty"`
->>>>>>> removed algorithm details in the struct
 	Payload             string      `json:"payload,omitempty"`
 	State               int         `json:"state,omitempty"`
 	EncryptionAlgorithm string      `json:"encryptionAlgorithm,omitempty"`
@@ -96,6 +92,10 @@ type KeysActionRequest struct {
 type KeyVersion struct {
 	ID           string     `json:"id,omitempty"`
 	CreationDate *time.Time `json:"creationDate,omitempty"`
+}
+
+type KeyRingID struct {
+	KeyRingID string `json:"keyRingID"`
 }
 
 // CreateKey creates a new KP key.
@@ -205,6 +205,26 @@ func (c *Client) createKey(ctx context.Context, key Key) (*Key, error) {
 	}
 
 	return &keysResponse.Keys[0], nil
+}
+
+// TransferKeyToNewKeyRing method transfers a key associated with one key ring to another key ring
+// For more information please refer to the link below:
+// https://cloud.ibm.com/docs/key-protect?topic=key-protect-grouping-keys#transfer-key-key-ring
+func (c *Client) TransferKeyToNewKeyRing(ctx context.Context, keyID, newKeyRingID string) (*Key, error) {
+	keyRingRequestBody := KeyRingID{
+		KeyRingID: newKeyRingID,
+	}
+
+	req, err := c.newRequest("PATCH", fmt.Sprintf("keys/%s", keyID), keyRingRequestBody)
+	if err != nil {
+		return nil, err
+	}
+
+	response := Keys{}
+	if _, err := c.do(ctx, req, &response); err != nil {
+		return nil, err
+	}
+	return &response.Keys[0], nil
 }
 
 // GetKeys retrieves a collection of keys that can be paged through.

--- a/keys.go
+++ b/keys.go
@@ -55,10 +55,12 @@ type Key struct {
 	KeyRingID           string      `json:"keyRingID,omitempty"`
 	Extractable         bool        `json:"extractable"`
 	Expiration          *time.Time  `json:"expirationDate,omitempty"`
-	Imported            bool        `json:"imported,omitempty"`
+	Imported            *bool       `json:"imported,omitempty"`
 	Payload             string      `json:"payload,omitempty"`
 	State               int         `json:"state,omitempty"`
 	EncryptionAlgorithm string      `json:"encryptionAlgorithm,omitempty"`
+	AlgorithmBitSize    string      `json:"algorithmBitSize,omitempty"`
+	AlgorithmMode       string      `json:"algorithmMode,omitempty"`
 	CRN                 string      `json:"crn,omitempty"`
 	EncryptedNonce      string      `json:"encryptedNonce,omitempty"`
 	IV                  string      `json:"iv,omitempty"`

--- a/keys.go
+++ b/keys.go
@@ -55,12 +55,14 @@ type Key struct {
 	KeyRingID           string      `json:"keyRingID,omitempty"`
 	Extractable         bool        `json:"extractable"`
 	Expiration          *time.Time  `json:"expirationDate,omitempty"`
+<<<<<<< HEAD
 	Imported            *bool       `json:"imported,omitempty"`
+=======
+	Imported            bool        `json:"imported,omitempty"`
+>>>>>>> removed algorithm details in the struct
 	Payload             string      `json:"payload,omitempty"`
 	State               int         `json:"state,omitempty"`
 	EncryptionAlgorithm string      `json:"encryptionAlgorithm,omitempty"`
-	AlgorithmBitSize    string      `json:"algorithmBitSize,omitempty"`
-	AlgorithmMode       string      `json:"algorithmMode,omitempty"`
 	CRN                 string      `json:"crn,omitempty"`
 	EncryptedNonce      string      `json:"encryptedNonce,omitempty"`
 	IV                  string      `json:"iv,omitempty"`

--- a/kp_test.go
+++ b/kp_test.go
@@ -2700,7 +2700,7 @@ func TestGetKeyRings(t *testing.T) {
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
 }
 
-func TestTransferKeyToNewKeyRing(t *testing.T) {
+func TestSetKeyRing(t *testing.T) {
 	defer gock.Off()
 	keyID := "d7e8-ce56-8197-147714"
 	newKeyRingID := "kungfuPanda01"
@@ -2744,7 +2744,7 @@ func TestTransferKeyToNewKeyRing(t *testing.T) {
 	defer gock.RestoreClient(&c.HttpClient)
 	c.tokenSource = &FakeTokenSource{}
 
-	key, err := c.TransferKeyToNewKeyRing(context.Background(), keyID, newKeyRingID)
+	key, err := c.SetKeyRing(context.Background(), keyID, newKeyRingID)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, key)

--- a/kp_test.go
+++ b/kp_test.go
@@ -2700,6 +2700,116 @@ func TestGetKeyRings(t *testing.T) {
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
 }
 
+func TestTransferKeyToNewKeyRing(t *testing.T) {
+	defer gock.Off()
+	keyID := "d7e8-ce56-8197-147714"
+	newKeyRingID := "kungfuPanda01"
+	keyResponse := []byte(`
+	{
+	"metadata": {
+		"collectionType": "application/vnd.ibm.kms.key+json",
+		"collectionTotal": 1
+	},
+	"resources": [
+		{
+		"type": "application/vnd.ibm.kms.key+json",
+		"id": "d7e8-ce56-8197-147714",
+		"name": "testing_key",
+		"state": 1,
+		"extractable": false,
+		"crn": "dummy:crn",
+		"imported": false,
+		"keyRingID": "kungfuPanda01",
+		"creationDate": "2021-02-11T20:22:38Z",
+		"createdBy": "abc-xyz",
+		"lastUpdateDate": "2021-03-23T03:16:21Z",
+		"keyVersion": {
+			"id": "d7e8-ce56-8197-147714"
+		},
+		"dualAuthDelete": {
+			"enabled": false
+		},
+		"deleted": false
+		}
+	]
+	}`)
+
+	gock.New("http://example.com").
+		Patch("/api/v2/keys/" + keyID).
+		Reply(200).
+		Body(bytes.NewReader((keyResponse)))
+
+	c, _, err := NewTestClient(t, nil)
+	gock.InterceptClient(&c.HttpClient)
+	defer gock.RestoreClient(&c.HttpClient)
+	c.tokenSource = &FakeTokenSource{}
+
+	key, err := c.TransferKeyToNewKeyRing(context.Background(), keyID, newKeyRingID)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, key)
+	assert.NotNil(t, key.KeyRingID)
+	assert.Equal(t, key.KeyRingID, "kungfuPanda01")
+
+	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
+}
+
+func TestGetKeyVerifyKeyRingDetail(t *testing.T) {
+	defer gock.Off()
+	keyID := "4177-ba1e-8082-952aafe"
+	keyResponse := []byte(`
+	{
+	"metadata": {
+		"collectionType": "application/vnd.ibm.kms.key+json",
+		"collectionTotal": 1
+	},
+	"resources": [
+		{
+		"type": "application/vnd.ibm.kms.key+json",
+		"id": "4177-ba1e-8082-952aafe",
+		"name": "keywithkeyring",
+		"state": 1,
+		"extractable": false,
+		"crn": "dummy:crn",
+		"imported": false,
+		"keyRingID": "sample-key-ring",
+		"creationDate": "2019-05-29T02:11:05Z",
+		"createdBy": "abc-xyz",
+		"lastUpdateDate": "2021-03-22T21:51:23Z",
+		"lastRotateDate": "2021-02-20T00:00:11Z",
+		"keyVersion": {
+			"id": "4177-ba1e-8082-952aafe"
+		},
+		"dualAuthDelete": {
+			"enabled": false
+		},
+		"deleted": false
+		}
+	]
+	}`)
+
+	gock.New("http://example.com").
+		Get("/api/v2/keys/" + keyID).
+		Reply(200).
+		Body(bytes.NewReader(keyResponse))
+
+	c, _, err := NewTestClient(t, nil)
+	gock.InterceptClient(&c.HttpClient)
+	defer gock.RestoreClient(&c.HttpClient)
+	c.tokenSource = &FakeTokenSource{}
+
+	key, err := c.GetKey(context.Background(), keyID)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, key)
+	assert.NotNil(t, key.KeyRingID)
+	assert.Equal(t, key.KeyRingID, "sample-key-ring")
+	assert.NotNil(t, key.Imported)
+	assert.False(t, *key.Imported)
+
+	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
+}
+
 func TestCreateKeyWithAliases(t *testing.T) {
 	defer gock.Off()
 	aliases := []string{"alias1", "alias2", "alias3"}

--- a/kp_test.go
+++ b/kp_test.go
@@ -2718,7 +2718,6 @@ func TestSetKeyRing(t *testing.T) {
 		"state": 1,
 		"extractable": false,
 		"crn": "dummy:crn",
-		"imported": false,
 		"keyRingID": "kungfuPanda01",
 		"creationDate": "2021-02-11T20:22:38Z",
 		"createdBy": "abc-xyz",
@@ -2771,7 +2770,7 @@ func TestGetKeyVerifyKeyRingDetail(t *testing.T) {
 		"state": 1,
 		"extractable": false,
 		"crn": "dummy:crn",
-		"imported": false,
+		"imported": true,
 		"keyRingID": "sample-key-ring",
 		"creationDate": "2019-05-29T02:11:05Z",
 		"createdBy": "abc-xyz",
@@ -2805,7 +2804,7 @@ func TestGetKeyVerifyKeyRingDetail(t *testing.T) {
 	assert.NotNil(t, key.KeyRingID)
 	assert.Equal(t, key.KeyRingID, "sample-key-ring")
 	assert.NotNil(t, key.Imported)
-	assert.False(t, *key.Imported)
+	assert.True(t, key.Imported)
 
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
 }


### PR DESCRIPTION
Associated with the issue: 473

Changes included in the PR: 
```
Added method TransferKeytoNewKeyRing
Updated unit tests for the method and the key structure change.
Fixed bug where the imported field is not shown in the response when false.
```