### PR TITLE
Support SHA1 for key creation operations

### DIFF
--- a/import_token.go
+++ b/import_token.go
@@ -32,7 +32,13 @@ import (
 	"time"
 )
 
-const importTokenEncAlgo = "RSAES_OAEP_SHA_256" // currently the only one supported
+// EncryptionAlgorithm represents the encryption algorithm used for key creation
+const (
+	// AlgorithmRSAOAEP256 denotes RSA OAEP SHA 256 encryption, supported by KP
+	AlgorithmRSAOAEP256 string = "RSAES_OAEP_SHA_256"
+	// AlgorithmRSAOAEP1 denotes RSA OAEP SHA 1 encryption, supported by HPCS
+	AlgorithmRSAOAEP1 string = "RSAES_OAEP_SHA_1"
+)
 
 // ImportTokenCreateRequest represents request parameters for creating a
 // ImportToken.

--- a/kp_test.go
+++ b/kp_test.go
@@ -125,6 +125,21 @@ func TestKeys(t *testing.T) {
 		},
 	}
 
+	testImportedKeySHA1 := &Keys{
+		Metadata: KeysMetadata{
+			CollectionType: "json",
+			NumberOfKeys:   1,
+		},
+		Keys: []Key{
+			Key{
+				ID:                  testKey,
+				Name:                "ImportedKey",
+				Extractable:         false,
+				EncryptionAlgorithm: AlgorithmRSAOAEP1,
+			},
+		},
+	}
+
 	keysActionDEK := KeysActionRequest{
 		PlainText:  "YWJjZGVmZ2hpamtsbW5vCg==",
 		CipherText: "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNA==",
@@ -653,6 +668,10 @@ func TestKeys(t *testing.T) {
 				_, err = api.CreateImportedKey(ctx, "test", nil, "", "", "", false)
 				assert.Error(t, err)
 
+				MockAuthURL(keyURL, http.StatusCreated, testImportedKeySHA1)
+				importedKey, err := api.CreateImportedKeyWithSHA1(ctx, "importedKeyWithSHA1", nil, "payload", "encryptedNonce", "iv", false, nil)
+				assert.NoError(t, err)
+				assert.Equal(t, AlgorithmRSAOAEP1, importedKey.EncryptionAlgorithm)
 				return nil
 			},
 		},


### PR DESCRIPTION
Support SHA1 for all key creation operations, this is only needed for HPCS ( Hyper Protect Crypto Services ). To avoid any disruption, this PR does not touch the existing exported function headers.