### PR TITLE
Updated method to perform sync request in sdk

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -520,6 +520,21 @@ func (c *Client) RotateV2(ctx context.Context, id string, new_key *KeyPayload) e
 	return nil
 }
 
+// SyncAssociatedResources method executes the sync request which verifies and updates
+// the resources associated with the key.
+// For more information please refer to the link below
+// https://cloud.ibm.com/docs/key-protect?topic=key-protect-sync-associated-resources
+func (c *Client) SyncAssociatedResources(ctx context.Context, id string) error {
+	req, err := c.newRequest("POST", fmt.Sprintf("keys/%s/actions/sync", id), nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.do(ctx, req, nil)
+
+	return err
+}
+
 // Disable a key. The key will not be deleted but it will not be active
 // and key operations cannot be performed on a disabled key.
 // For more information can refer to the Key Protect docs in the link below:

--- a/kp_test.go
+++ b/kp_test.go
@@ -3634,3 +3634,41 @@ func TestRotate2ImportedKeyWithoutPayload(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "This root key was created with user-supplied key material")
 }
+
+func TestSyncAssociatedResources(t *testing.T){
+	defer gock.Off()
+	keyID := "dummy-key-id"
+
+	gock.New("http://example.com").
+		Post("/api/v2/keys/" + keyID + "/actions/sync").
+		Reply(204)
+
+	c, _, err := NewTestClient(t, nil)
+	gock.InterceptClient(&c.HttpClient)
+	defer gock.RestoreClient(&c.HttpClient)
+	c.tokenSource = &FakeTokenSource{}
+
+	err = c.SyncAssociatedResources(context.Background(), keyID)
+
+	assert.NoError(t, err)
+	assert.True(t, gock.IsDone(), "Expected HTTP requests not called")
+}
+
+func TestSyncAssociatedResourcesError(t *testing.T){
+	defer gock.Off()
+	keyID := "dummy-key-id"
+
+	gock.New("http://example.com").
+		Post("/api/v2/keys/" + keyID + "/actions/sync").
+		Reply(400)
+
+	c, _, err := NewTestClient(t, nil)
+	gock.InterceptClient(&c.HttpClient)
+	defer gock.RestoreClient(&c.HttpClient)
+	c.tokenSource = &FakeTokenSource{}
+
+	err = c.SyncAssociatedResources(context.Background(), keyID)
+
+	assert.Error(t, err)
+	assert.True(t, gock.IsDone(), "Expected HTTP requests not called")
+}

--- a/kp_test.go
+++ b/kp_test.go
@@ -3657,10 +3657,30 @@ func TestSyncAssociatedResources(t *testing.T){
 func TestSyncAssociatedResourcesError(t *testing.T){
 	defer gock.Off()
 	keyID := "dummy-key-id"
+	errorResp := []byte(`{
+		"metadata":{
+			"collectionType":"application/vnd.ibm.kms.error+json",
+			"collectionTotal":1
+		},
+		"resources":[
+			{
+				"errorMsg":"Conflict: Could not initiate sync requests to associated resources: Please see 'reasons' for more details (REQ_TOO_EARLY_ERR)",
+				"reasons":[
+					{
+						"code":"REQ_TOO_EARLY_ERR",
+						"message":"The key was updated recently: Please wait and try again: Sync cannot be performed until at least 2021-09-29T21:38:43Z",
+						"status":409,
+						"moreInfo":"https://cloud.ibm.com/apidocs/key-protect"
+					}
+				]
+			}
+		]
+	}`)
 
 	gock.New("http://example.com").
 		Post("/api/v2/keys/" + keyID + "/actions/sync").
-		Reply(400)
+		Reply(409).
+		Body(bytes.NewReader(errorResp))
 
 	c, _, err := NewTestClient(t, nil)
 	gock.InterceptClient(&c.HttpClient)
@@ -3670,5 +3690,6 @@ func TestSyncAssociatedResourcesError(t *testing.T){
 	err = c.SyncAssociatedResources(context.Background(), keyID)
 
 	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "The key was updated recently: Please wait and try again: Sync cannot be performed until at least")
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called")
 }


### PR DESCRIPTION
Associated with the issue: kms/kpcp#252

Changes included in the PR: 
```
Added method to perform sync request. 
Update unit tests for the method
```