### PR TITLE
Updated the path for actions from query param to extension in the request path

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -507,12 +507,7 @@ func (c *Client) RotateV2(ctx context.Context, id string, new_key *KeyPayload) e
 		}
 	}
 
-	req, err := c.newRequest("POST", fmt.Sprintf("keys/%s/actions/rotate", id), actionReq)
-	if err != nil {
-		return err
-	}
-
-	_, err = c.do(ctx, req, nil)
+	_, err := c.doKeysAction(ctx, id, "rotate", actionReq)
 	if err != nil {
 		return err
 	}
@@ -561,15 +556,10 @@ func (c *Client) CancelDualAuthDelete(ctx context.Context, id string) error {
 func (c *Client) doKeysAction(ctx context.Context, id string, action string, keysActionReq *KeysActionRequest) (*KeysActionRequest, error) {
 	keyActionRsp := KeysActionRequest{}
 
-	v := url.Values{}
-	v.Set("action", action)
-
-	req, err := c.newRequest("POST", fmt.Sprintf("keys/%s", id), keysActionReq)
+	req, err := c.newRequest("POST", fmt.Sprintf("keys/%s/actions/%s", id, action), keysActionReq)
 	if err != nil {
 		return nil, err
 	}
-
-	req.URL.RawQuery = v.Encode()
 
 	_, err = c.do(ctx, req, &keyActionRsp)
 	if err != nil {

--- a/kp_test.go
+++ b/kp_test.go
@@ -2490,8 +2490,7 @@ func TestDisableKey(t *testing.T) {
 	}`)
 
 	gock.New("http://example.com").
-		Post("/api/v2/keys/"+testKey).
-		MatchParam("action", "disable").
+		Post("/api/v2/keys/"+testKey+"/actions/disable").
 		Reply(204)
 
 	c, _, err := NewTestClient(t, nil)
@@ -2560,8 +2559,7 @@ func TestEnableKey(t *testing.T) {
 	`)
 
 	gock.New("http://example.com").
-		Post("/api/v2/keys/"+testKey).
-		MatchParam("action", "enable").
+		Post("/api/v2/keys/"+testKey+"/actions/enable").
 		Reply(204)
 
 	c, _, err := NewTestClient(t, nil)
@@ -2591,8 +2589,7 @@ func TestInitiate_DualAuthDelete(t *testing.T) {
 	keyID := "4309-akld"
 
 	gock.New("http://example.com").
-		Post("/api/v2/keys/"+keyID).
-		MatchParam("action", "setKeyForDeletion").
+		Post("/api/v2/keys/"+keyID+"/actions/setKeyForDeletion").
 		Reply(204)
 
 	c, _, err := NewTestClient(t, nil)
@@ -2611,8 +2608,7 @@ func TestCancel_DualAuthDelete(t *testing.T) {
 	defer gock.Off()
 	keyID := "4839-adhf"
 	gock.New("http://example.com").
-		Post("/api/v2/keys/"+keyID).
-		MatchParam("action", "unsetKeyForDeletion").
+		Post("/api/v2/keys/"+keyID+"/actions/unsetKeyForDeletion").
 		Reply(204)
 
 	c, _, err := NewTestClient(t, nil)


### PR DESCRIPTION
Associated with the issue: kms/kpcp#249

Changes included in the PR: 
```
Updated the internal method from a query param to an extension in the request path.
Updated the unit tests accordingly.
```