### PR TITLE
Added KeyCount func, State and Extractable Parameters

### DIFF
--- a/example_cycle_test.go
+++ b/example_cycle_test.go
@@ -37,7 +37,7 @@ func Example() {
 	ctx := context.Background()
 
 	// List keys in the current instance
-	keys, err := c.GetKeys(ctx, 0, 0)
+	keys, err := c.GetKeys(ctx, 0, 0, []int{0, 1, 2, 3}, true)
 	if err != nil {
 		panic(err)
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 // Copyright 2019 IBM Corp.
@@ -73,7 +74,7 @@ func TestWrapUnwrap(t *testing.T) {
 
 	ctx := context.Background()
 
-	keys, err := c.GetKeys(ctx, 0, 0)
+	keys, err := c.GetKeys(ctx, 0, 0, []int{0, 1, 2, 3})
 	assert.NoError(err)
 
 	for _, key := range keys.Keys {
@@ -90,7 +91,7 @@ func TestWrapUnwrap(t *testing.T) {
 	unwrapped, err := c.Unwrap(ctx, crk.ID, wdek, nil)
 	assert.EqualValues(unwrapped, ptDek)
 
-	keys, err = c.GetKeys(context.Background(), 0, 0)
+	keys, err = c.GetKeys(context.Background(), 0, 0, []int{0, 1, 2, 3})
 	assert.NoError(err)
 
 	for _, key := range keys.Keys {
@@ -113,7 +114,7 @@ func TestRotatedKeyHasLastUpdatedAndRotated(t *testing.T) {
 
 	ctx := context.Background()
 
-	keys, err := c.GetKeys(ctx, 0, 0)
+	keys, err := c.GetKeys(ctx, 0, 0, []int{0, 1, 2, 3})
 	assert.NoError(err)
 
 	for _, key := range keys.Keys {
@@ -136,7 +137,7 @@ func TestRotatedKeyHasLastUpdatedAndRotated(t *testing.T) {
 	assert.NotEmpty(rotated.LastUpdateDate)
 	assert.NotEmpty(rotated.LastRotateDate)
 
-	keys, err = c.GetKeys(context.Background(), 0, 0)
+	keys, err = c.GetKeys(context.Background(), 0, 0, []int{0, 1, 2, 3})
 	assert.NoError(err)
 
 	for _, key := range keys.Keys {
@@ -165,7 +166,7 @@ func TestExtractableKey(t *testing.T) {
 
 	ctx := context.Background()
 
-	keys, err := c.GetKeys(ctx, 0, 0)
+	keys, err := c.GetKeys(ctx, 0, 0, []int{0, 1, 2, 3}, true)
 	assert.NoError(err)
 
 	for _, key := range keys.Keys {
@@ -193,7 +194,7 @@ func TestExtractableKey(t *testing.T) {
 	_, err = c.Unwrap(ctx, crk.ID, []byte("wdek"), nil)
 	assert.Error(err)
 
-	keys, err = c.GetKeys(context.Background(), 0, 0)
+	keys, err = c.GetKeys(context.Background(), 0, 0, []int{0, 1, 2, 3}, false)
 	assert.NoError(err)
 
 	for _, key := range keys.Keys {

--- a/kp_test.go
+++ b/kp_test.go
@@ -238,7 +238,7 @@ func TestKeys(t *testing.T) {
 			func(t *testing.T, api *API, ctx context.Context) error {
 				MockAuthURL(keyURL, http.StatusOK, testKeys)
 
-				keys, err := api.GetKeys(ctx, 10, 0)
+				keys, err := api.GetKeys(ctx, 10, 0, []int{0, 1, 2, 3})
 				assert.NoError(t, err)
 				assert.NotZero(t, keys.Metadata.NumberOfKeys)
 
@@ -314,7 +314,7 @@ func TestKeys(t *testing.T) {
 			"Imported Create Delete",
 			func(t *testing.T, api *API, ctx context.Context) error {
 				MockAuthURL(keyURL, http.StatusOK, testKeys)
-				ks, err := api.GetKeys(ctx, 100, 0)
+				ks, err := api.GetKeys(ctx, 100, 0, []int{0, 1, 2, 3})
 				assert.NoError(t, err)
 				startCount := ks.Metadata.NumberOfKeys
 				testKeys.Keys = append([]Key{*newRootKey}, testKeys.Keys...)
@@ -335,7 +335,7 @@ func TestKeys(t *testing.T) {
 				key2 := k.ID
 
 				MockAuthURL(keyURL, http.StatusOK, testKeys)
-				ks, err = api.GetKeys(ctx, 100, 0)
+				ks, err = api.GetKeys(ctx, 100, 0, []int{0, 1, 2, 3})
 				assert.NoError(t, err)
 				assert.Equal(t, startCount+2, ks.Metadata.NumberOfKeys, "Created 2 keys, counts don't match")
 				testKeys.Keys = append(testKeys.Keys[:1], testKeys.Keys[2:]...)
@@ -352,7 +352,7 @@ func TestKeys(t *testing.T) {
 				assert.NoError(t, err)
 
 				MockAuthURL(keyURL, http.StatusOK, testKeys)
-				ks, err = api.GetKeys(ctx, 0, 0)
+				ks, err = api.GetKeys(ctx, 0, 0, []int{0, 1, 2, 3})
 				assert.NoError(t, err)
 				assert.Equal(t, startCount, ks.Metadata.NumberOfKeys, "Deleted 2 keys, counts don't match")
 				return nil
@@ -362,7 +362,7 @@ func TestKeys(t *testing.T) {
 			"Create Delete",
 			func(t *testing.T, api *API, ctx context.Context) error {
 				MockAuthURL(keyURL, http.StatusOK, testKeys)
-				ks, err := api.GetKeys(ctx, 100, 0)
+				ks, err := api.GetKeys(ctx, 100, 0, []int{0, 1, 2, 3})
 				assert.NoError(t, err)
 				startCount := ks.Metadata.NumberOfKeys
 				testKeys.Keys = append([]Key{*newRootKey}, testKeys.Keys...)
@@ -382,7 +382,7 @@ func TestKeys(t *testing.T) {
 				key2 := k.ID
 
 				MockAuthURL(keyURL, http.StatusOK, testKeys)
-				ks, err = api.GetKeys(ctx, 100, 0)
+				ks, err = api.GetKeys(ctx, 100, 0, []int{0, 1, 2, 3})
 				assert.NoError(t, err)
 				assert.Equal(t, startCount+2, ks.Metadata.NumberOfKeys, "Created 2 keys, counts don't match")
 				testKeys.Keys = append(testKeys.Keys[:1], testKeys.Keys[2:]...)
@@ -399,7 +399,7 @@ func TestKeys(t *testing.T) {
 				assert.NoError(t, err)
 
 				MockAuthURL(keyURL, http.StatusOK, testKeys)
-				ks, err = api.GetKeys(ctx, 0, 0)
+				ks, err = api.GetKeys(ctx, 0, 0, []int{0, 1, 2, 3})
 				assert.NoError(t, err)
 				assert.Equal(t, startCount, ks.Metadata.NumberOfKeys, "Deleted 2 keys, counts don't match")
 
@@ -486,7 +486,7 @@ func TestKeys(t *testing.T) {
 
 				body := "context deadline exceeded"
 				MockAuthURL(keyURL, http.StatusRequestTimeout, "").BodyString(body)
-				_, err = a.GetKeys(ctx, 0, 0)
+				_, err = a.GetKeys(ctx, 0, 0, []int{0, 1, 2, 3})
 				assert.Contains(t, err.Error(), body)
 				return nil
 			},
@@ -498,7 +498,7 @@ func TestKeys(t *testing.T) {
 				ctx = NewContextWithAuth(ctx, accessToken)
 				body := "Bad Request: Token is expired"
 				MockAuthURL(keyURL, http.StatusBadRequest, "").BodyString(body)
-				_, err := api.GetKeys(ctx, 0, 0)
+				_, err := api.GetKeys(ctx, 0, 0, []int{0, 1, 2, 3})
 				assert.Contains(t, err.Error(), body)
 				return nil
 			},
@@ -519,7 +519,7 @@ func TestKeys(t *testing.T) {
 
 				body := "Bad Request: Token is expired"
 				MockAuthURL(keyURL, http.StatusBadRequest, "").BodyString(body)
-				_, err = a.GetKeys(ctx, 0, 0)
+				_, err = a.GetKeys(ctx, 0, 0, []int{0, 1, 2, 3})
 				assert.Contains(t, err.Error(), body)
 				return nil
 			},
@@ -565,7 +565,7 @@ func TestKeys(t *testing.T) {
 				gock.New("https://iam.bluemix.net/oidc/token").Reply(http.StatusRequestTimeout).BodyString(body)
 				gock.InterceptClient(&a.HttpClient)
 
-				_, err = a.GetKeys(ctx, 0, 0)
+				_, err = a.GetKeys(ctx, 0, 0, []int{0, 1, 2, 3})
 				// failing ATM:
 				//assert.EqualError(t, err, "context deadline exceeded")
 				return nil
@@ -609,7 +609,7 @@ func TestKeys(t *testing.T) {
 				gock.New("https://iam.cloud.ibm.com/oidc/token").Reply(http.StatusBadRequest).JSON(body)
 				gock.InterceptClient(&a.HttpClient)
 
-				_, err = api.GetKeys(ctx, 0, 0)
+				_, err = api.GetKeys(ctx, 0, 0, []int{0, 1, 2, 3})
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), "BXNIM0415E")
 				assert.Contains(t, err.Error(), "Provided API key could not be found")
@@ -1029,7 +1029,7 @@ func TestDo_ConnectionError_HasCorrelationID(t *testing.T) {
 	defer gock.RestoreClient(&c.HttpClient)
 	c.tokenSource = &FakeTokenSource{}
 
-	keys, err := c.GetKeys(context.Background(), 0, 0)
+	keys, err := c.GetKeys(context.Background(), 0, 0, []int{0, 1, 2, 3})
 
 	assert.Nil(t, keys)
 	assert.Error(t, err)
@@ -1052,7 +1052,7 @@ func TestDo_CorrelationID_Set(t *testing.T) {
 
 	corrID := uuid.New()
 	ctx := NewContextWithCorrelationID(context.Background(), &corrID)
-	_, err = c.GetKeys(ctx, 0, 0)
+	_, err = c.GetKeys(ctx, 0, 0, []int{0, 1, 2, 3})
 	assert.Contains(t, err.Error(), "correlation_id='"+corrID.String()+"'")
 	corrID2 := GetCorrelationID(ctx)
 	assert.Equal(t, &corrID, corrID2)
@@ -1122,7 +1122,7 @@ func TestDo_KPErrorResponseWithoutReasons_IsErrorStruct(t *testing.T) {
 	defer gock.RestoreClient(&c.HttpClient)
 	c.tokenSource = &FakeTokenSource{}
 
-	_, err = c.GetKeys(context.Background(), 0, 0)
+	_, err = c.GetKeys(context.Background(), 0, 0, []int{0, 1, 2, 3})
 
 	reasonsErr := err.(*Error)
 


### PR DESCRIPTION
<details open>
<summary>➜  keyprotect-go-client git:(KeyUpdate) ✗ go test -v</summary>
<pre>
=== RUN   TestKeys
=== RUN   TestKeys/New_API
=== RUN   TestKeys/New_API_with_Logger
=== RUN   TestKeys/Timeout
=== RUN   TestKeys/Get_Keys
=== RUN   TestKeys/Wrap_Create_DEK
=== RUN   TestKeys/Wrap_Unwrap_v2
=== RUN   TestKeys/Unwrap_on_Deleted_should_return_err_with_410_Gone
=== RUN   TestKeys/Imported_Create_Delete
=== RUN   TestKeys/Create_Delete
=== RUN   TestKeys/Imported_Rotate
=== RUN   TestKeys/Imported_Rotate_Unwrap
=== RUN   TestKeys/Rotate_Unwrap
=== RUN   TestKeys/Timeout#01
=== RUN   TestKeys/Auth_Context
=== RUN   TestKeys/Auth_in_Config
=== RUN   TestKeys/Wrap_and_Unwrap_AAD
=== RUN   TestKeys/API_Key_Timeout
=== RUN   TestKeys/Bad_Config
=== RUN   TestKeys/Bad_API_Key
=== RUN   TestKeys/Create_Key_Without_Expiration
=== RUN   TestKeys/Create
=== RUN   TestKeys/Rotate
=== RUN   TestKeys/Get_Key
=== RUN   TestKeys/Get_Key_Metadata
=== RUN   TestKeys/Wrap_Unwrap
=== RUN   TestKeys/Delete_Key
=== RUN   TestKeys/Create_Standard_Key
=== RUN   TestKeys/Create_Imported_Standard_Key
--- PASS: TestKeys (0.01s)
    --- PASS: TestKeys/New_API (0.00s)
    --- PASS: TestKeys/New_API_with_Logger (0.00s)
    --- PASS: TestKeys/Timeout (0.00s)
    --- PASS: TestKeys/Get_Keys (0.00s)
    --- PASS: TestKeys/Wrap_Create_DEK (0.00s)
    --- PASS: TestKeys/Wrap_Unwrap_v2 (0.00s)
    --- PASS: TestKeys/Unwrap_on_Deleted_should_return_err_with_410_Gone (0.00s)
    --- PASS: TestKeys/Imported_Create_Delete (0.00s)
    --- PASS: TestKeys/Create_Delete (0.00s)
    --- PASS: TestKeys/Imported_Rotate (0.00s)
    --- PASS: TestKeys/Imported_Rotate_Unwrap (0.00s)
    --- PASS: TestKeys/Rotate_Unwrap (0.00s)
    --- PASS: TestKeys/Timeout#01 (0.00s)
    --- PASS: TestKeys/Auth_Context (0.00s)
    --- PASS: TestKeys/Auth_in_Config (0.00s)
    --- PASS: TestKeys/Wrap_and_Unwrap_AAD (0.00s)
    --- PASS: TestKeys/API_Key_Timeout (0.00s)
    --- PASS: TestKeys/Bad_Config (0.00s)
    --- PASS: TestKeys/Bad_API_Key (0.00s)
    --- PASS: TestKeys/Create_Key_Without_Expiration (0.00s)
    --- PASS: TestKeys/Create (0.00s)
    --- PASS: TestKeys/Rotate (0.00s)
    --- PASS: TestKeys/Get_Key (0.00s)
    --- PASS: TestKeys/Get_Key_Metadata (0.00s)
    --- PASS: TestKeys/Wrap_Unwrap (0.00s)
    --- PASS: TestKeys/Delete_Key (0.00s)
    --- PASS: TestKeys/Create_Standard_Key (0.00s)
    --- PASS: TestKeys/Create_Imported_Standard_Key (0.00s)
=== RUN   TestMisc
=== RUN   TestMisc/Redact_Values
--- PASS: TestMisc (0.00s)
    --- PASS: TestMisc/Redact_Values (0.00s)
=== RUN   TestImportTokens
=== RUN   TestImportTokens/ImportToken_Create
=== RUN   TestImportTokens/ImportToken_Get
=== RUN   TestImportTokens/Assert_context_authorization_override
=== RUN   TestImportTokens/Dump_Implementations
--- PASS: TestImportTokens (0.00s)
    --- PASS: TestImportTokens/ImportToken_Create (0.00s)
    --- PASS: TestImportTokens/ImportToken_Get (0.00s)
    --- PASS: TestImportTokens/Assert_context_authorization_override (0.00s)
    --- PASS: TestImportTokens/Dump_Implementations (0.00s)
=== RUN   TestKPCheckRetry
=== RUN   TestKPCheckRetry/No_retry_on_successful_codes
=== RUN   TestKPCheckRetry/No_retry_on_400-level_codes
=== RUN   TestKPCheckRetry/Retry_on_429
=== RUN   TestKPCheckRetry/Retry_on_500+
=== RUN   TestKPCheckRetry/No_retry_on_501
=== RUN   TestKPCheckRetry/Retry_on_connection_failures
=== RUN   TestKPCheckRetry/No_retry_on_context_failures
--- PASS: TestKPCheckRetry (0.00s)
    --- PASS: TestKPCheckRetry/No_retry_on_successful_codes (0.00s)
    --- PASS: TestKPCheckRetry/No_retry_on_400-level_codes (0.00s)
    --- PASS: TestKPCheckRetry/Retry_on_429 (0.00s)
    --- PASS: TestKPCheckRetry/Retry_on_500+ (0.00s)
    --- PASS: TestKPCheckRetry/No_retry_on_501 (0.00s)
    --- PASS: TestKPCheckRetry/Retry_on_connection_failures (0.00s)
    --- PASS: TestKPCheckRetry/No_retry_on_context_failures (0.00s)
=== RUN   TestDo_ConnectionError_HasCorrelationID
--- PASS: TestDo_ConnectionError_HasCorrelationID (0.00s)
=== RUN   TestDo_CorrelationID_Set
--- PASS: TestDo_CorrelationID_Set (0.00s)
=== RUN   TestDo_KPErrorResponseWithReasons_IsErrorStruct
--- PASS: TestDo_KPErrorResponseWithReasons_IsErrorStruct (0.00s)
=== RUN   TestDo_KPErrorResponseWithoutReasons_IsErrorStruct
--- PASS: TestDo_KPErrorResponseWithoutReasons_IsErrorStruct (0.00s)
=== RUN   TestDeleteKey_ForceOptTrue_URLHasForce
--- PASS: TestDeleteKey_ForceOptTrue_URLHasForce (0.00s)
=== RUN   TestDeleteKey_WithRegistrations_ErrorCases
--- PASS: TestDeleteKey_WithRegistrations_ErrorCases (0.00s)
=== RUN   TestRegistrationsList
--- PASS: TestRegistrationsList (0.00s)
=== RUN   TestRestoreKey
--- PASS: TestRestoreKey (0.00s)
=== RUN   TestSetAndGetMultipleInstancePolicies
--- PASS: TestSetAndGetMultipleInstancePolicies (0.00s)
=== RUN   TestSetAndGetDualAuthInstancePolicy
--- PASS: TestSetAndGetDualAuthInstancePolicy (0.00s)
=== RUN   TestSetAndGetAllowedNetworkPolicy
--- PASS: TestSetAndGetAllowedNetworkPolicy (0.00s)
=== RUN   TestSetAndGetAllowedIPInstancePolicy
--- PASS: TestSetAndGetAllowedIPInstancePolicy (0.00s)
=== RUN   TestSetAndGetKeyCreateImportAccessInstancePolicy
--- PASS: TestSetAndGetKeyCreateImportAccessInstancePolicy (0.00s)
=== RUN   TestSetMetricsPolicy
--- PASS: TestSetMetricsPolicy (0.00s)
=== RUN   TestSetAllowedIPPolicyError
--- PASS: TestSetAllowedIPPolicyError (0.00s)
=== RUN   TestGetPrivateEndpointPortNumber
--- PASS: TestGetPrivateEndpointPortNumber (0.00s)
=== RUN   TestSetInstanceDualAuthPolicyError
--- PASS: TestSetInstanceDualAuthPolicyError (0.00s)
=== RUN   TestSetKeyPolicies
--- PASS: TestSetKeyPolicies (0.00s)
=== RUN   TestGetKeyPolicies
--- PASS: TestGetKeyPolicies (0.00s)
=== RUN   TestDisableKey
--- PASS: TestDisableKey (0.00s)
=== RUN   TestEnableKey
--- PASS: TestEnableKey (0.00s)
=== RUN   TestInitiate_DualAuthDelete
--- PASS: TestInitiate_DualAuthDelete (0.00s)
=== RUN   TestCancel_DualAuthDelete
--- PASS: TestCancel_DualAuthDelete (0.00s)
=== RUN   TestCreateKeyRing
--- PASS: TestCreateKeyRing (0.00s)
=== RUN   TestDeleteKeyRing
--- PASS: TestDeleteKeyRing (0.00s)
=== RUN   TestGetKeyRings
--- PASS: TestGetKeyRings (0.00s)
=== RUN   TestCreateKeyWithAliases
--- PASS: TestCreateKeyWithAliases (0.00s)
=== RUN   TestCreateImportedKeyWithAliases
--- PASS: TestCreateImportedKeyWithAliases (0.00s)
=== RUN   TestCreateKeyAlias
--- PASS: TestCreateKeyAlias (0.00s)
=== RUN   TestDeleteKeyAlias
--- PASS: TestDeleteKeyAlias (0.00s)
=== RUN   TestGetKeyWithAlias
--- PASS: TestGetKeyWithAlias (0.00s)
=== RUN   TestGetKeyMetadataWithAlias
--- PASS: TestGetKeyMetadataWithAlias (0.00s)
PASS
ok      github.com/IBM/keyprotect-go-client     0.994s
</pre>
</details>