### PR TITLE
Adding list key version api in go sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,3 +171,12 @@ dek = nil
 // Save the wrapped DEK for later.  Call Unwrap to use it, make
 // sure to specify the same AAD.
 ```
+### Fetching Key Versions With Parameters.
+
+```go
+keyVersions, count, err := client.GetKeyVersions(ctx, "key_id", WithLimit(1), WithOffset(0), WithTotalCount(true))
+if err != nil {
+    fmt.Println(err)
+}
+fmt.Println(keyVersions, count)
+```

--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ dek = nil
 
 ```go
 
-limit := int64(2)
-offset := int64(0)
+limit := uint32(2)
+offset := uint32(0)
 totalCount := true
 
 listkeyVersionsOptions := &kp.ListKeyVersionsOptions{
@@ -185,27 +185,27 @@ listkeyVersionsOptions := &kp.ListKeyVersionsOptions{
   TotalCount : &totalCount,
 }
 
-keyVersions, count, err := client.ListKeyVersions(ctx, "key_id", listkeyVersionsOptions)
+keyVersions, err := client.ListKeyVersions(ctx, "key_id", listkeyVersionsOptions)
 if err != nil {
     fmt.Println(err)
 }
-fmt.Println(keyVersions, count)
+fmt.Println(keyVersions)
 ```
 
 ### Fetching List Key With Parameters.
 
 ```go
 
-limit := int64(5)
-offset := int64(0)
+limit := uint32(5)
+offset := uint32(0)
 extractable := false
-states := []int{1, 2, 3}
+keyStates := []kp.KeyState{kp.KeyState(kp.Active), kp.KeyState(kp.Suspended)}
 
 listKeysOptions := &kp.ListKeysOptions{
   Limit : &limit,
   Offset : &offset,
   Extractable : &extractable,
-  State : states,
+  State : keyStates,
 }
 
 keys, err := client.ListKeys(ctx, listKeysOptions)

--- a/README.md
+++ b/README.md
@@ -179,11 +179,11 @@ limit := int64(2)
 offset := int64(0)
 totalCount := true
 
-listkeyVersionsOptions := api.NewListKeyVersionsOptions()
-
-listkeyVersionsOptions.Limit = &limit
-listkeyVersionsOptions.Offset = &offset
-listkeyVersionsOptions.TotalCount = &totalCount
+listkeyVersionsOptions := &kp.ListKeyVersionsOptions{
+  Limit : &limit,
+  Offset : &offset,
+  TotalCount : &totalCount,
+}
 
 keyVersions, count, err := client.GetKeyVersions(ctx, "key_id", listkeyVersionsOptions)
 if err != nil {
@@ -196,17 +196,17 @@ fmt.Println(keyVersions, count)
 
 ```go
 
-l := int64(5)
-o := int64(0)
-e := false
-s := []int{1, 2, 3}
+limit := int64(5)
+offset := int64(0)
+extractable := false
+states := []int{1, 2, 3}
 
-listKeysOptions := client.NewListKeysOptions()
-
-listKeysOptions.Limit = &l
-listKeysOptions.Offset = &o
-listKeysOptions.Extractable = &e
-listKeysOptions.State = &s
+listKeysOptions := &kp.ListKeysOptions{
+  Limit : &limit,
+  Offset : &offset,
+  Extractable : &extractable,
+  State : &states,
+}
 
 keys, err := client.ListKeys(ctx, listKeysOptions)
 if err != nil {

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ dek = nil
 // Save the wrapped DEK for later.  Call Unwrap to use it, make
 // sure to specify the same AAD.
 ```
-### Fetching Key Versions With Parameters.
+### Fetching List Key Versions With Parameters.
 
 ```go
 
@@ -185,7 +185,7 @@ listkeyVersionsOptions := &kp.ListKeyVersionsOptions{
   TotalCount : &totalCount,
 }
 
-keyVersions, count, err := client.GetKeyVersions(ctx, "key_id", listkeyVersionsOptions)
+keyVersions, count, err := client.ListKeyVersions(ctx, "key_id", listkeyVersionsOptions)
 if err != nil {
     fmt.Println(err)
 }
@@ -205,7 +205,7 @@ listKeysOptions := &kp.ListKeysOptions{
   Limit : &limit,
   Offset : &offset,
   Extractable : &extractable,
-  State : &states,
+  State : states,
 }
 
 keys, err := client.ListKeys(ctx, listKeysOptions)

--- a/README.md
+++ b/README.md
@@ -174,9 +174,43 @@ dek = nil
 ### Fetching Key Versions With Parameters.
 
 ```go
-keyVersions, count, err := client.GetKeyVersions(ctx, "key_id", WithLimit(1), WithOffset(0), WithTotalCount(true))
+
+limit := int64(2)
+offset := int64(0)
+totalCount := true
+
+listkeyVersionsOptions := api.NewListKeyVersionsOptions()
+
+listkeyVersionsOptions.Limit = &limit
+listkeyVersionsOptions.Offset = &offset
+listkeyVersionsOptions.TotalCount = &totalCount
+
+keyVersions, count, err := client.GetKeyVersions(ctx, "key_id", listkeyVersionsOptions)
 if err != nil {
     fmt.Println(err)
 }
 fmt.Println(keyVersions, count)
+```
+
+### Fetching List Key With Parameters.
+
+```go
+
+l := int64(5)
+o := int64(0)
+e := false
+s := []int{1, 2, 3}
+
+listKeysOptions := client.NewListKeysOptions()
+
+listKeysOptions.Limit = &l
+listKeysOptions.Offset = &o
+listKeysOptions.Extractable = &e
+listKeysOptions.State = &s
+
+keys, err := client.ListKeys(ctx, listKeysOptions)
+if err != nil {
+    fmt.Println(err)
+}
+fmt.Println(keys)
 ```

--- a/keys.go
+++ b/keys.go
@@ -275,12 +275,12 @@ func (c *Client) GetKeys(ctx context.Context, limit int, offset int) (*Keys, err
 	return &keys, nil
 }
 
-//listKeyVersionsOptions struct to handle the query paramters for the List Key Versions
+//ListKeysOptions struct to add the query parameters for the List Keys function
 type ListKeysOptions struct {
-	Extractable *bool  `json:"extractable,omitempty"`
-	Limit       *int64 `json:"limit,omitempty"`
-	Offset      *int64 `json:"offset,omitempty"`
-	State       *[]int `json:"state,omitempty"`
+	Extractable *bool
+	Limit       *uint64
+	Offset      *uint64
+	State       []int
 }
 
 //ListKeys retrieves a list of keys that are stored in your Key Protect service instance.
@@ -293,26 +293,25 @@ func (c *Client) ListKeys(ctx context.Context, listKeysOptions *ListKeysOptions)
 
 	// extracting the query parameters and encoding the same in the request url
 	if listKeysOptions != nil {
-		v := url.Values{}
+		values := req.URL.Query()
 		if listKeysOptions.Limit != nil {
-			v.Set("limit", fmt.Sprint(*listKeysOptions.Limit))
+			values.Set("limit", fmt.Sprint(*listKeysOptions.Limit))
 		}
 		if listKeysOptions.Offset != nil {
-			v.Set("offset", fmt.Sprint(*listKeysOptions.Offset))
+			values.Set("offset", fmt.Sprint(*listKeysOptions.Offset))
 		}
 		if listKeysOptions.State != nil {
 			var states []string
-			for _, i := range *listKeysOptions.State {
+			for _, i := range listKeysOptions.State {
 				states = append(states, strconv.Itoa(i))
 			}
 
-			v.Set("state", strings.Join(states, ","))
+			values.Set("state", strings.Join(states, ","))
 		}
 		if listKeysOptions.Extractable != nil {
-			v.Set("extractable", fmt.Sprint(*listKeysOptions.Extractable))
+			values.Set("extractable", fmt.Sprint(*listKeysOptions.Extractable))
 		}
-
-		req.URL.RawQuery = v.Encode()
+		req.URL.RawQuery = values.Encode()
 	}
 
 	keys := Keys{}
@@ -363,15 +362,15 @@ type ForceOpt struct {
 	Force bool
 }
 
-//listKeyVersionsOptions struct to handle the query paramters for the List Key Versions
+//ListKeyVersionsOptions struct to add the query parameters for the ListKeyVersions function
 type ListKeyVersionsOptions struct {
-	Limit      *int64 `json:"limit,omitempty"`
-	Offset     *int64 `json:"offset,omitempty"`
-	TotalCount *bool  `json:"totalCount,omitempty"`
+	Limit      *uint64
+	Offset     *uint64
+	TotalCount *bool
 }
 
-// GetKeyVersion gets all the versions of the key resource by specifying ID of the key and/or optional parameteres
-func (c *Client) GetKeyVersions(ctx context.Context, id string, listKeyVersionsOptions *ListKeyVersionsOptions) (*KeyVersions, int, error) {
+// ListKeyVersions gets all the versions of the key resource by specifying ID of the key and/or optional parameteres
+func (c *Client) ListKeyVersions(ctx context.Context, id string, listKeyVersionsOptions *ListKeyVersionsOptions) (*KeyVersions, int, error) {
 	keyVersion := KeyVersions{}
 	// forming the request
 	req, err := c.newRequest("GET", fmt.Sprintf("keys/%s/versions", id), nil)
@@ -380,19 +379,19 @@ func (c *Client) GetKeyVersions(ctx context.Context, id string, listKeyVersionsO
 	}
 
 	// extracting the query parameters and encoding the same in the request url
-	v := url.Values{}
 	if listKeyVersionsOptions != nil {
+		values := req.URL.Query()
 		if listKeyVersionsOptions.Limit != nil {
-			v.Set("limit", fmt.Sprint(*listKeyVersionsOptions.Limit))
+			values.Set("limit", fmt.Sprint(*listKeyVersionsOptions.Limit))
 		}
 		if listKeyVersionsOptions.Offset != nil {
-			v.Set("offset", fmt.Sprint(*listKeyVersionsOptions.Offset))
+			values.Set("offset", fmt.Sprint(*listKeyVersionsOptions.Offset))
 		}
 		if listKeyVersionsOptions.TotalCount != nil {
-			v.Set("totalCount", fmt.Sprint(*listKeyVersionsOptions.TotalCount))
+			values.Set("totalCount", fmt.Sprint(*listKeyVersionsOptions.TotalCount))
 		}
+		req.URL.RawQuery = values.Encode()
 	}
-	req.URL.RawQuery = v.Encode()
 
 	//making a request
 	_, err = c.do(ctx, req, &keyVersion)

--- a/keys.go
+++ b/keys.go
@@ -275,20 +275,16 @@ func (c *Client) GetKeys(ctx context.Context, limit int, offset int) (*Keys, err
 	return &keys, nil
 }
 
-func (c *Client) NewListKeysOptions() *listKeysOptions {
-	return &listKeysOptions{}
-}
-
 //listKeyVersionsOptions struct to handle the query paramters for the List Key Versions
-type listKeysOptions struct {
+type ListKeysOptions struct {
+	Extractable *bool  `json:"extractable,omitempty"`
 	Limit       *int64 `json:"limit,omitempty"`
 	Offset      *int64 `json:"offset,omitempty"`
 	State       *[]int `json:"state,omitempty"`
-	Extractable *bool  `json:"extractable,omitempty"`
 }
 
 //ListKeys retrieves a list of keys that are stored in your Key Protect service instance.
-func (c *Client) ListKeys(ctx context.Context, optsInput *listKeysOptions) (*Keys, error) {
+func (c *Client) ListKeys(ctx context.Context, listKeysOptions *ListKeysOptions) (*Keys, error) {
 
 	req, err := c.newRequest("GET", "keys", nil)
 	if err != nil {
@@ -296,24 +292,24 @@ func (c *Client) ListKeys(ctx context.Context, optsInput *listKeysOptions) (*Key
 	}
 
 	// extracting the query parameters and encoding the same in the request url
-	if optsInput != nil {
+	if listKeysOptions != nil {
 		v := url.Values{}
-		if optsInput.Limit != nil {
-			v.Set("limit", fmt.Sprint(*optsInput.Limit))
+		if listKeysOptions.Limit != nil {
+			v.Set("limit", fmt.Sprint(*listKeysOptions.Limit))
 		}
-		if optsInput.Offset != nil {
-			v.Set("offset", fmt.Sprint(*optsInput.Offset))
+		if listKeysOptions.Offset != nil {
+			v.Set("offset", fmt.Sprint(*listKeysOptions.Offset))
 		}
-		if optsInput.State != nil {
+		if listKeysOptions.State != nil {
 			var states []string
-			for _, i := range *optsInput.State {
+			for _, i := range *listKeysOptions.State {
 				states = append(states, strconv.Itoa(i))
 			}
 
 			v.Set("state", strings.Join(states, ","))
 		}
-		if optsInput.Extractable != nil {
-			v.Set("extractable", fmt.Sprint(*optsInput.Extractable))
+		if listKeysOptions.Extractable != nil {
+			v.Set("extractable", fmt.Sprint(*listKeysOptions.Extractable))
 		}
 
 		req.URL.RawQuery = v.Encode()
@@ -367,19 +363,15 @@ type ForceOpt struct {
 	Force bool
 }
 
-func (c *Client) NewListKeyVersionsOptions() *listKeyVersionsOptions {
-	return &listKeyVersionsOptions{}
-}
-
 //listKeyVersionsOptions struct to handle the query paramters for the List Key Versions
-type listKeyVersionsOptions struct {
+type ListKeyVersionsOptions struct {
 	Limit      *int64 `json:"limit,omitempty"`
 	Offset     *int64 `json:"offset,omitempty"`
 	TotalCount *bool  `json:"totalCount,omitempty"`
 }
 
 // GetKeyVersion gets all the versions of the key resource by specifying ID of the key and/or optional parameteres
-func (c *Client) GetKeyVersions(ctx context.Context, id string, optsInput *listKeyVersionsOptions) (*KeyVersions, int, error) {
+func (c *Client) GetKeyVersions(ctx context.Context, id string, listKeyVersionsOptions *ListKeyVersionsOptions) (*KeyVersions, int, error) {
 	keyVersion := KeyVersions{}
 	// forming the request
 	req, err := c.newRequest("GET", fmt.Sprintf("keys/%s/versions", id), nil)
@@ -389,15 +381,15 @@ func (c *Client) GetKeyVersions(ctx context.Context, id string, optsInput *listK
 
 	// extracting the query parameters and encoding the same in the request url
 	v := url.Values{}
-	if optsInput != nil {
-		if optsInput.Limit != nil {
-			v.Set("limit", fmt.Sprint(*optsInput.Limit))
+	if listKeyVersionsOptions != nil {
+		if listKeyVersionsOptions.Limit != nil {
+			v.Set("limit", fmt.Sprint(*listKeyVersionsOptions.Limit))
 		}
-		if optsInput.Offset != nil {
-			v.Set("offset", fmt.Sprint(*optsInput.Offset))
+		if listKeyVersionsOptions.Offset != nil {
+			v.Set("offset", fmt.Sprint(*listKeyVersionsOptions.Offset))
 		}
-		if optsInput.TotalCount != nil {
-			v.Set("totalCount", fmt.Sprint(*optsInput.TotalCount))
+		if listKeyVersionsOptions.TotalCount != nil {
+			v.Set("totalCount", fmt.Sprint(*listKeyVersionsOptions.TotalCount))
 		}
 	}
 	req.URL.RawQuery = v.Encode()

--- a/kp.go
+++ b/kp.go
@@ -25,9 +25,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
@@ -80,32 +78,6 @@ type ClientConfig struct {
 	KeyRing       string  // The ID of the target Key Ring the key is associated with. It is optional but recommended for better performance.
 	Verbose       int     // See verbose values above
 	Timeout       float64 // KP request timeout in seconds.
-}
-
-func queryParamReqOpt(key string, val string) reqOpt {
-	return func(r *http.Request) {
-		q := r.URL.Query()
-		q.Set(key, val)
-		r.URL.RawQuery = q.Encode()
-	}
-}
-
-type reqOpt func(r *http.Request)
-
-func WithForce(force bool) reqOpt {
-	return queryParamReqOpt("force", strconv.FormatBool(force))
-}
-
-func WithLimit(limit int) reqOpt {
-	return queryParamReqOpt("limit", strconv.Itoa(limit))
-}
-
-func WithOffset(offset int) reqOpt {
-	return queryParamReqOpt("offset", strconv.Itoa(offset))
-}
-
-func WithTotalCount(totalCount bool) reqOpt {
-	return queryParamReqOpt("totalCount", strconv.FormatBool(totalCount))
 }
 
 // DefaultTransport ...
@@ -260,7 +232,7 @@ func (e URLError) Error() string {
 		"error during request to KeyProtect correlation_id='%s': %s", e.CorrelationID, e.Err.Error())
 }
 
-func (c *Client) do(ctx context.Context, req *http.Request, res interface{}, opts ...reqOpt) (*http.Response, error) {
+func (c *Client) do(ctx context.Context, req *http.Request, res interface{}) (*http.Response, error) {
 
 	acccesToken, err := c.getAccessToken(ctx)
 	if err != nil {
@@ -279,14 +251,6 @@ func (c *Client) do(ctx context.Context, req *http.Request, res interface{}, opt
 	req.Header.Set("bluemix-instance", c.Config.InstanceID)
 	req.Header.Set("authorization", acccesToken)
 	req.Header.Set("correlation-id", corrID)
-
-	for _, opt := range opts {
-		opt(req)
-	}
-	_, err = httputil.DumpRequestOut(req, true)
-	if err != nil {
-		return nil, err
-	}
 
 	if c.Config.KeyRing != "" {
 		req.Header.Set("x-kms-key-ring", c.Config.KeyRing)

--- a/kp_test.go
+++ b/kp_test.go
@@ -763,13 +763,16 @@ func TestKeys(t *testing.T) {
 			func(t *testing.T, api *API, ctx context.Context) error {
 				//Successful call
 				MockAuthURL(keyURL, http.StatusOK, testKeyVersions)
-				listkeyVersions := api.NewListKeyVersionsOptions()
+
 				limit := int64(2)
 				offset := int64(0)
 				totalCount := true
-				listkeyVersions.Limit = &limit
-				listkeyVersions.Offset = &offset
-				listkeyVersions.TotalCount = &totalCount
+				listkeyVersions := &ListKeyVersionsOptions{
+					Limit:      &limit,
+					Offset:     &offset,
+					TotalCount: &totalCount,
+				}
+
 				keyVersions, count, err := api.GetKeyVersions(ctx, testKey, listkeyVersions)
 				assert.NoError(t, err)
 				assert.Equal(t, testKey, keyVersions.KeyVersion[0].ID)
@@ -3549,11 +3552,12 @@ func TestGetKeyVersions(t *testing.T) {
 	defer gock.RestoreClient(&c.HttpClient)
 	c.tokenSource = &FakeTokenSource{}
 
-	listkeyVersions := c.NewListKeyVersionsOptions()
 	limit := int64(2)
 	totalCount := true
-	listkeyVersions.Limit = &limit
-	listkeyVersions.TotalCount = &totalCount
+	listkeyVersions := &ListKeyVersionsOptions{
+		Limit:      &limit,
+		TotalCount: &totalCount,
+	}
 
 	keyVersion, count, err := c.GetKeyVersions(context.Background(), key_id, listkeyVersions)
 	assert.NoError(t, err)

--- a/kp_test.go
+++ b/kp_test.go
@@ -759,13 +759,13 @@ func TestKeys(t *testing.T) {
 			},
 		},
 		{
-			"Get Key Version",
+			"List Key Versions",
 			func(t *testing.T, api *API, ctx context.Context) error {
 				//Successful call
 				MockAuthURL(keyURL, http.StatusOK, testKeyVersions)
 
-				limit := int64(2)
-				offset := int64(0)
+				limit := uint64(2)
+				offset := uint64(0)
 				totalCount := true
 				listkeyVersions := &ListKeyVersionsOptions{
 					Limit:      &limit,
@@ -773,7 +773,7 @@ func TestKeys(t *testing.T) {
 					TotalCount: &totalCount,
 				}
 
-				keyVersions, count, err := api.GetKeyVersions(ctx, testKey, listkeyVersions)
+				keyVersions, count, err := api.ListKeyVersions(ctx, testKey, listkeyVersions)
 				assert.NoError(t, err)
 				assert.Equal(t, testKey, keyVersions.KeyVersion[0].ID)
 				assert.Equal(t, testKeyVersions.Metadata.TotalCount, count)
@@ -3527,17 +3527,27 @@ func TestGetKeyMetadataWithAlias(t *testing.T) {
 
 func TestGetKeyVersions(t *testing.T) {
 	defer gock.Off()
-	getResponse := []byte(`{
+
+	// Case 1: when a user passes invalid value in limit
+	KeyVersionResponse := []byte(`{
 		"metadata": {
 			"collectionTotal": 1,
 			"collectionType": "application/vnd.ibm.kms.key+json",
-			"totalCount": 1
 		},
 		"resources": [
 			{
-				"id": "2n4y2-4ko2n-4m23f-23j3r",
-				"creationDate": "2021-03-08T22:47:01Z"
-			}
+				"StatusCode": 400,
+				"Message": "Bad Request: KeyVersion(s) could not be retrieved: Please see for more details (INVALID_QUERY_PARAM_ERR)",
+				"CorrelationID": "63f9f89d-0ad3-486f-9b49-2470a78fa080",
+				"Reasons": [
+				  {
+					"Code": "INVALID_QUERY_PARAM_ERR",
+					"Message": "The query_param must be: an integer between 1 and 5000 (inclusive)",
+					"Status": 400,
+					"MoreInfo": "https://cloud.ibm.com/apidocs/key-protect"
+				  }
+				]
+			  }
 		]
 		}`)
 
@@ -3545,25 +3555,306 @@ func TestGetKeyVersions(t *testing.T) {
 
 	gock.New("http://example.com").
 		Get("/api/v2/keys/" + key_id + "/versions").
-		Reply(200).Body(bytes.NewReader(getResponse))
+		MatchParams(map[string]string{"limit": "0", "totalCount": "true"}).
+		Reply(400).Body(bytes.NewReader(KeyVersionResponse))
 
 	c, _, err := NewTestClient(t, nil)
 	gock.InterceptClient(&c.HttpClient)
 	defer gock.RestoreClient(&c.HttpClient)
 	c.tokenSource = &FakeTokenSource{}
 
-	limit := int64(2)
+	limit := uint64(0)
 	totalCount := true
 	listkeyVersions := &ListKeyVersionsOptions{
 		Limit:      &limit,
 		TotalCount: &totalCount,
 	}
 
-	keyVersion, count, err := c.GetKeyVersions(context.Background(), key_id, listkeyVersions)
+	keyVersion, count, err := c.ListKeyVersions(context.Background(), key_id, listkeyVersions)
+	assert.Error(t, err)
+	assert.Nil(t, keyVersion)
+	assert.EqualValues(t, 0, count)
+	assert.Contains(t, err.Error(), "INVALID_QUERY_PARAM_ERR")
+
+	// Case 2: When user enters valid values
+	KeyVersionResponse = []byte(`{
+		"metadata": {
+			"collectionTotal": 1,
+			"collectionType": "application/vnd.ibm.kms.key+json",
+			"totalCount": 3
+		},
+		"resources": [
+			{
+				"id": "2n4y2-4ko2n-4m23f-23j3p",
+				"creationDate": "2021-03-08T22:47:01Z"
+			},
+			{
+				"id": "2n4y2-4ko2n-4m23f-23j3q",
+				"creationDate": "2021-03-08T22:47:01Z"
+			},
+			{
+				"id": "2n4y2-4ko2n-4m23f-23j3r",
+				"creationDate": "2021-03-08T22:47:01Z"
+			}
+		]
+		}`)
+
+	gock.New("http://example.com").
+		Get("/api/v2/keys/" + key_id + "/versions").
+		MatchParams(map[string]string{"limit": "3", "totalCount": "true"}).
+		Reply(200).Body(bytes.NewReader(KeyVersionResponse))
+
+	limit = uint64(3)
+	totalCount = true
+	listkeyVersions = &ListKeyVersionsOptions{
+		Limit:      &limit,
+		TotalCount: &totalCount,
+	}
+
+	keyVersion, count, err = c.ListKeyVersions(context.Background(), key_id, listkeyVersions)
 	assert.NoError(t, err)
 	assert.NotNil(t, keyVersion)
-	assert.NotNil(t, count)
-	assert.Equal(t, key_id, keyVersion.KeyVersion[0].ID)
+	assert.EqualValues(t, 3, count)
+
+	// Case 3: Calling ListKeyVersions with default values
+	KeyVersionResponse = []byte(`{
+		"metadata": {
+			"collectionTotal": 1,
+			"collectionType": "application/vnd.ibm.kms.key+json"
+		},
+		"resources": [
+			{
+				"id": "2n4y2-4ko2n-4m23f-23j3p",
+				"creationDate": "2021-03-08T22:47:01Z"
+			},
+			{
+				"id": "2n4y2-4ko2n-4m23f-23j3q",
+				"creationDate": "2021-03-08T22:47:01Z"
+			},
+			{
+				"id": "2n4y2-4ko2n-4m23f-23j3r",
+				"creationDate": "2021-03-08T22:47:01Z"
+			}
+		]
+		}`)
+
+	gock.New("http://example.com").
+		Get("/api/v2/keys/" + key_id + "/versions").
+		Reply(200).Body(bytes.NewReader(KeyVersionResponse))
+
+	listkeyVersions = &ListKeyVersionsOptions{}
+
+	keyVersion, count, err = c.ListKeyVersions(context.Background(), key_id, listkeyVersions)
+	assert.NoError(t, err)
+	assert.NotNil(t, keyVersion)
+	assert.EqualValues(t, 0, count) //Since totalCount is false
+}
+
+func TestListKeys(t *testing.T) {
+	defer gock.Off()
+
+	// Case 1 : When user sends the limit more than the total keys present in an instance, offset=0 and extractable=false
+	listKeyResponse := []byte(`{
+		"metadata": 
+		{
+		  "collectionType": "application/vnd.ibm.kms.key+json",
+		  "collectionTotal": 2
+		},
+		"resources": [
+			{
+				"id": "12ka4-12ka4-12ka4-12ka4",
+				"name": "Key29March",
+				"type": "application/vnd.ibm.kms.key+json",
+				"aliases": [
+			  		"alias01",
+			  		"alias1"
+				],
+				"algorithmType": "AES",
+				"createdBy": "IBMid-55xxxxx",
+				"creationDate": "2022-03-29T11:27:40Z",
+				"lastUpdateDate": "2022-04-19T11:28:27Z",
+				"lastRotateDate": "2022-04-08T06:34:10Z",
+				"keyVersion": {
+				"id": "42ka1-42ka1-42ka1-42ka1",
+				"creationDate": "2022-04-08T06:34:10Z"
+				},
+				"keyRingID": "default",
+				"extractable": false,
+				"state": 2,
+				"crn": "crn:v1:bluemix:public:kms:us-south:a/acount-id:some-nice-instance-id:key:key:12ka4-12ka4-12ka4-12ka4",
+				"deleted": false,
+				"dualAuthDelete": {
+				"enabled": false
+				}
+			},
+			{
+				"id": "12ka4-12ka4-12ka4-12ka5",
+				"name": "Key1",
+				"type": "application/vnd.ibm.kms.key+json",
+				"algorithmType": "AES",
+				"createdBy": "IBMid-55xxxxx",
+				"creationDate": "2022-04-12T08:30:34Z",
+				"lastUpdateDate": "2022-04-12T14:19:24Z",
+				"lastRotateDate": "2022-04-12T14:19:24Z",
+				"keyVersion": {
+				  "id": "42ka1-42ka1-42ka1-42ka2",
+				  "creationDate": "2022-04-12T14:19:24Z"
+				},
+				"keyRingID": "default",
+				"extractable": false,
+				"state": 1,
+				"crn": "crn:v1:bluemix:public:kms:us-south:a/acount-id:some-nice-instance-id:key:key:12ka4-12ka4-12ka4-12ka5",
+				"deleted": false,
+				"dualAuthDelete": {
+				  "enabled": false
+				}
+			}
+		]
+	}`)
+
+	gock.New("http://example.com").
+		Get("/api/v2/keys").
+		MatchParams(map[string]string{"limit": "3", "offset": "0", "extractable": "false"}).
+		Reply(200).
+		Body(bytes.NewReader(listKeyResponse))
+
+	c, _, err := NewTestClient(t, nil)
+	gock.InterceptClient(&c.HttpClient)
+	defer gock.RestoreClient(&c.HttpClient)
+	c.tokenSource = &FakeTokenSource{}
+
+	limit := uint64(3)
+	offset := uint64(0)
+	extractable := false
+	listKeysOptions := &ListKeysOptions{
+		Limit:       &limit,
+		Offset:      &offset,
+		Extractable: &extractable,
+	}
+
+	keys, err := c.ListKeys(context.Background(), listKeysOptions)
+	assert.NoError(t, err)
+	assert.NotNil(t, keys)
+
+	/* 	Case 2 : When user sends the limit more than the total keys present in an instance, offset=0, extractable=true
+	and wants to list keys which has state either 1 or 2 */
+	listKeyResponse = []byte(`{
+		"metadata": 
+		{
+		  "collectionType": "application/vnd.ibm.kms.key+json",
+		  "collectionTotal": 2
+		},
+		"resources": [
+			{
+				"id": "12ka4-12ka4-12ka4-12ka4",
+				"name": "Key29March",
+				"type": "application/vnd.ibm.kms.key+json",
+				"aliases": [
+			  		"alias01",
+			  		"alias1"
+				],
+				"algorithmType": "AES",
+				"createdBy": "IBMid-55xxxxx",
+				"creationDate": "2022-03-29T11:27:40Z",
+				"lastUpdateDate": "2022-04-19T11:28:27Z",
+				"lastRotateDate": "2022-04-08T06:34:10Z",
+				"keyVersion": {
+				"id": "42ka1-42ka1-42ka1-42ka1",
+				"creationDate": "2022-04-08T06:34:10Z"
+				},
+				"keyRingID": "default",
+				"extractable": true,
+				"state": 2,
+				"crn": "crn:v1:bluemix:public:kms:us-south:a/acount-id:some-nice-instance-id:key:key:12ka4-12ka4-12ka4-12ka4",
+				"deleted": false,
+				"dualAuthDelete": {
+				"enabled": false
+				}
+			},
+			{
+				"id": "12ka4-12ka4-12ka4-12ka5",
+				"name": "Key1",
+				"type": "application/vnd.ibm.kms.key+json",
+				"algorithmType": "AES",
+				"createdBy": "IBMid-55xxxxx",
+				"creationDate": "2022-04-12T08:30:34Z",
+				"lastUpdateDate": "2022-04-12T14:19:24Z",
+				"lastRotateDate": "2022-04-12T14:19:24Z",
+				"keyVersion": {
+				  "id": "42ka1-42ka1-42ka1-42ka2",
+				  "creationDate": "2022-04-12T14:19:24Z"
+				},
+				"keyRingID": "default",
+				"extractable": true,
+				"state": 1,
+				"crn": "crn:v1:bluemix:public:kms:us-south:a/acount-id:some-nice-instance-id:key:key:12ka4-12ka4-12ka4-12ka5",
+				"deleted": false,
+				"dualAuthDelete": {
+				  "enabled": false
+				}
+			}
+		]
+	}`)
+
+	gock.New("http://example.com").
+		Get("/api/v2/keys").
+		MatchParams(map[string]string{"limit": "3", "offset": "0", "extractable": "true", "state": "1,2"}).
+		Reply(200).
+		Body(bytes.NewReader(listKeyResponse))
+
+	extractable = true
+	states := []int{1, 2}
+	listKeysOptions = &ListKeysOptions{
+		Limit:       &limit,
+		Offset:      &offset,
+		Extractable: &extractable,
+		State:       states,
+	}
+
+	keys, err = c.ListKeys(context.Background(), listKeysOptions)
+	assert.NoError(t, err)
+	assert.NotNil(t, keys)
+
+	// Case 3: When a user passes invalid data
+	listKeyResponse = []byte(`{
+		"metadata": {
+			"collectionTotal": 1,
+			"collectionType": "application/vnd.ibm.kms.key+json"
+		},
+		"resources": [
+			{
+				"StatusCode": 400,
+				"Message": "Bad Request: Keys could not be retrieved: Please see for more details (INVALID_QUERY_PARAM_ERR)",
+				"CorrelationID": "63f9f89d-0ad3-486f-9b49-2470a78fa080",
+				"Reasons": [
+				  {
+					"Code": "INVALID_QUERY_PARAM_ERR",
+					"Message": "The query_param must be: an integer between 1 and 5000 (inclusive)",
+					"Status": 400,
+					"MoreInfo": "https://cloud.ibm.com/apidocs/key-protect"
+				  }
+				]
+			  }
+		]
+		}`)
+
+	gock.New("http://example.com").
+		Get("/api/v2/keys").
+		MatchParams(map[string]string{"limit": "0", "offset": "0", "extractable": "true"}).
+		Reply(400).
+		Body(bytes.NewReader(listKeyResponse))
+
+	limit = uint64(0)
+	listKeysOptions = &ListKeysOptions{
+		Limit:       &limit,
+		Offset:      &offset,
+		Extractable: &extractable,
+	}
+
+	keys, err = c.ListKeys(context.Background(), listKeysOptions)
+	assert.Error(t, err)
+	assert.Nil(t, keys)
+	assert.Contains(t, err.Error(), "INVALID_QUERY_PARAM_ERR")
 }
 
 func TestRotate2WithoutPayload(t *testing.T) {

--- a/kp_test.go
+++ b/kp_test.go
@@ -763,7 +763,14 @@ func TestKeys(t *testing.T) {
 			func(t *testing.T, api *API, ctx context.Context) error {
 				//Successful call
 				MockAuthURL(keyURL, http.StatusOK, testKeyVersions)
-				keyVersions, count, err := api.GetKeyVersions(ctx, testKey, WithLimit(2), WithOffset(0), WithTotalCount(true))
+				listkeyVersions := api.NewListKeyVersionsOptions()
+				limit := int64(2)
+				offset := int64(0)
+				totalCount := true
+				listkeyVersions.Limit = &limit
+				listkeyVersions.Offset = &offset
+				listkeyVersions.TotalCount = &totalCount
+				keyVersions, count, err := api.GetKeyVersions(ctx, testKey, listkeyVersions)
 				assert.NoError(t, err)
 				assert.Equal(t, testKey, keyVersions.KeyVersion[0].ID)
 				assert.Equal(t, testKeyVersions.Metadata.TotalCount, count)
@@ -3542,7 +3549,13 @@ func TestGetKeyVersions(t *testing.T) {
 	defer gock.RestoreClient(&c.HttpClient)
 	c.tokenSource = &FakeTokenSource{}
 
-	keyVersion, count, err := c.GetKeyVersions(context.Background(), key_id, WithLimit(1), WithTotalCount(true))
+	listkeyVersions := c.NewListKeyVersionsOptions()
+	limit := int64(2)
+	totalCount := true
+	listkeyVersions.Limit = &limit
+	listkeyVersions.TotalCount = &totalCount
+
+	keyVersion, count, err := c.GetKeyVersions(context.Background(), key_id, listkeyVersions)
 	assert.NoError(t, err)
 	assert.NotNil(t, keyVersion)
 	assert.NotNil(t, count)


### PR DESCRIPTION
This is PR to add the [List Key Version](https://cloud.ibm.com/apidocs/key-protect#getkeyversions) functionality in go sdk.