### PR TITLE
Adding instance rotation policy in SDK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ if err != nil {
 fmt.Println(keys)
 ```
 
-### Enable/Disable Instance Rotation Policy.
+### Enable or disable Instance Rotation Policy.
 
 ```go
 

--- a/README.md
+++ b/README.md
@@ -220,10 +220,16 @@ fmt.Println(keys)
 ```go
 
 intervalMonth := 3
-enable := false
+enable := true
 
-err := client.SetRotationInstancePolicy(ctx, enable, &intervalMonth)
+err := client.SetRotationInstancePolicy(context.Background(), enable, &intervalMonth)
 if err != nil {
     fmt.Println(err)
 }
+
+rotationInstancePolicy, err := client.GetRotationInstancePolicy(context.Background())
+if err != nil {
+  fmt.Println(err)
+}
+fmt.Println(rotationInstancePolicy)
 ```

--- a/README.md
+++ b/README.md
@@ -214,3 +214,16 @@ if err != nil {
 }
 fmt.Println(keys)
 ```
+
+### Enable/Disable Instance Rotation Policy.
+
+```go
+
+intervalMonth := 3
+enable := false
+
+err := client.SetRotationInstancePolicy(ctx, enable, &intervalMonth)
+if err != nil {
+    fmt.Println(err)
+}
+```

--- a/instances.go
+++ b/instances.go
@@ -263,7 +263,7 @@ func (c *Client) SetDualAuthInstancePolicy(ctx context.Context, enable bool) err
 	return err
 }
 
-// SetAllowedIPInstancePolices updates the rotation instance policy details associated with an instance.
+// SetRotationInstancePolicy updates the rotation instance policy details associated with an instance.
 // For more information can refet to the Key Protect docs in the link below:
 // will update soon
 func (c *Client) SetRotationInstancePolicy(ctx context.Context, enable bool, intervalMonth *int) error {

--- a/instances.go
+++ b/instances.go
@@ -37,8 +37,8 @@ const (
 	// KeyAccess defines the policy type as key create import access
 	KeyCreateImportAccess = "keyCreateImportAccess"
 
-	// RotationInstancePolicy defines the policy type as rotation instance policy
-	RotationInstancePolicy = "rotation"
+	//RotationPolicy defines the policy type as rotation
+	RotationPolicy = "rotation"
 
 	// KeyAccess policy attributes
 	CreateRootKey     = "CreateRootKey"
@@ -195,7 +195,7 @@ func (c *Client) GetMetricsInstancePolicy(ctx context.Context) (*InstancePolicy,
 func (c *Client) GetRotationInstancePolicy(ctx context.Context) (*InstancePolicy, error) {
 	policyResponse := InstancePolicies{}
 
-	err := c.getInstancePolicy(ctx, RotationInstancePolicy, &policyResponse)
+	err := c.getInstancePolicy(ctx, RotationPolicy, &policyResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -269,15 +269,16 @@ func (c *Client) SetDualAuthInstancePolicy(ctx context.Context, enable bool) err
 func (c *Client) SetRotationInstancePolicy(ctx context.Context, enable bool, intervalMonth *int) error {
 
 	rotationPolicyData := InstancePolicy{
-		PolicyType: RotationInstancePolicy,
+		PolicyType: RotationPolicy,
 		PolicyData: PolicyData{
 			Enabled: &enable,
 		},
 	}
 
 	if intervalMonth != nil {
-		rotationPolicyData.PolicyData.Attributes = &Attributes{}
-		rotationPolicyData.PolicyData.Attributes.IntervalMonth = intervalMonth
+		rotationPolicyData.PolicyData.Attributes = &Attributes{
+			IntervalMonth: intervalMonth,
+		}
 	}
 
 	policyRequest := InstancePolicies{
@@ -288,7 +289,7 @@ func (c *Client) SetRotationInstancePolicy(ctx context.Context, enable bool, int
 		Policies: []InstancePolicy{rotationPolicyData},
 	}
 
-	err := c.setInstancePolicy(ctx, RotationInstancePolicy, policyRequest)
+	err := c.setInstancePolicy(ctx, RotationPolicy, policyRequest)
 	if err != nil {
 		return err
 	}
@@ -550,20 +551,18 @@ func (c *Client) SetInstancePolicies(ctx context.Context, policies MultiplePolic
 	}
 
 	if policies.Rotation != nil {
-
-		policyData := PolicyData{}
-		policyData.Enabled = &policies.Rotation.Enabled
-
-		attribute := Attributes{}
-		if policies.Rotation.IntervalMonth != nil {
-			attribute.IntervalMonth = policies.Rotation.IntervalMonth
-			policyData.Attributes = &attribute
-		}
-
 		policy := InstancePolicy{
-			PolicyType: RotationInstancePolicy,
-			PolicyData: policyData,
+			PolicyType: RotationPolicy,
+			PolicyData: PolicyData{
+				Enabled: &policies.Rotation.Enabled,
+			},
 		}
+		if policies.Rotation.IntervalMonth != nil {
+			policy.PolicyData.Attributes = &Attributes{
+				IntervalMonth: policies.Rotation.IntervalMonth,
+			}
+		}
+
 		resPolicies = append(resPolicies, policy)
 	}
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -238,3 +238,59 @@ func TestExtractableKey(t *testing.T) {
 		}
 	}
 }
+
+func TestRotationInstancePolicy(t *testing.T) {
+	assert := assert.New(t)
+
+	c, err := NewIntegrationTestClient(t)
+	assert.NoError(err)
+
+	ctx := context.Background()
+
+	// creating instance rotation policy
+	intervalMonth := 3
+	err = c.SetRotationInstancePolicy(ctx, true, &intervalMonth)
+	assert.NoError(err)
+
+	// getting instance rotation policy
+	rotationPolicy, err := c.GetRotationInstancePolicy(context.Background())
+	assert.NoError(err)
+	assert.EqualValues(*rotationPolicy.PolicyData.Attributes.IntervalMonth, intervalMonth)
+	assert.True(*rotationPolicy.PolicyData.Enabled)
+
+	//creating a key
+	crk, err := c.CreateKey(ctx, "root", nil, false)
+	assert.NoError(err)
+
+	// Fetching rotation key policies for the above created key
+	policy, err := c.GetRotationPolicy(ctx, crk.ID)
+	assert.NoError(err)
+	assert.EqualValues(policy.Rotation.Interval, intervalMonth)
+
+	// deleting the key
+	_, err = c.DeleteKey(ctx, crk.ID, 0)
+	assert.NoError(err)
+
+	//disable the instance rotation policy
+	err = c.SetRotationInstancePolicy(ctx, false, nil)
+	assert.NoError(err)
+
+	// verify if rotation policy is disabled or not
+	rotationPolicy, err = c.GetRotationInstancePolicy(context.Background())
+	assert.NoError(err)
+	assert.False(*rotationPolicy.PolicyData.Enabled)
+
+	// creating a key
+	crk, err = c.CreateKey(ctx, "root", nil, false)
+	assert.NoError(err)
+
+	// created key should not have any key rotation policies associated with it.
+	policy, err = c.GetRotationPolicy(ctx, crk.ID)
+	assert.NoError(err)
+	assert.Nil(policy)
+
+	// deleting the key
+	_, err = c.DeleteKey(ctx, crk.ID, 0)
+	assert.NoError(err)
+
+}

--- a/kp_test.go
+++ b/kp_test.go
@@ -1543,6 +1543,12 @@ func TestSetAndGetMultipleInstancePolicies(t *testing.T) {
 	// 				"enabled": true,
 	// 			},
 	// 		},
+	//		{
+	// 			"policy_type": "metrics",
+	// 			"policy_data": map[string]interface{}{
+	// 				"enabled": true,
+	// 			},
+	// 		},
 	// 		{
 	// 			"policy_type": "allowedNetwork",
 	// 			"policy_data": map[string]interface{}{
@@ -1576,6 +1582,16 @@ func TestSetAndGetMultipleInstancePolicies(t *testing.T) {
 				"lastUpdated": "2020-06-08T17:11:38Z",
 				"updatedBy": "xyz6",
 				"policy_type": "dualAuthDelete",
+				"policy_data": {
+				"enabled": true
+				}
+			},
+			{
+				"createdBy": "pqr",
+				"creationDate": "2022-04-22T15:16:23Z",
+				"lastUpdated": "2022-06-08T17:11:38Z",
+				"updatedBy": "pqr",
+				"policy_type": "metrics",
 				"policy_data": {
 				"enabled": true
 				}
@@ -1623,7 +1639,7 @@ func TestSetAndGetMultipleInstancePolicies(t *testing.T) {
 		Enabled: true,
 		Network: "private-only",
 	}
-	intervalMonth := 2
+	intervalMonth := 3
 	rotationInstancePolicy := &RotationPolicyData{
 		Enabled:       true,
 		IntervalMonth: &intervalMonth,
@@ -1654,7 +1670,7 @@ func TestSetAndGetMultipleInstancePolicies(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, ap)
-	assert.Greater(t, len(ap), -1)
+	assert.Equal(t, len(ap), 4)
 
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
 
@@ -2419,7 +2435,7 @@ func TestSetInstanceDualAuthPolicyError(t *testing.T) {
 //TestSetRotationInstancePolicyError tests the methods set rotation instance policy to error out with attributes field.
 func TestSetRotationInstancePolicyError(t *testing.T) {
 	/*
-		Case-1 : When a user set the interval_month more 12 months in the request.
+		Case-1 : When a user set the interval_month greater than 12 months in the request.
 	*/
 
 	defer gock.Off()

--- a/kp_test.go
+++ b/kp_test.go
@@ -1640,7 +1640,7 @@ func TestSetAndGetMultipleInstancePolicies(t *testing.T) {
 		Network: "private-only",
 	}
 	intervalMonth := 3
-	rotationInstancePolicy := &RotationPolicyData{
+	rotation := &RotationPolicyData{
 		Enabled:       true,
 		IntervalMonth: &intervalMonth,
 	}
@@ -1648,7 +1648,7 @@ func TestSetAndGetMultipleInstancePolicies(t *testing.T) {
 		Metrics:        metrics,
 		DualAuthDelete: dualAuth,
 		AllowedNetwork: allowedNetwork,
-		Rotation:       rotationInstancePolicy,
+		Rotation:       rotation,
 	}
 
 	gock.New("http://example.com").
@@ -1746,8 +1746,8 @@ func TestSetAndGetDualAuthInstancePolicy(t *testing.T) {
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
 }
 
-// TestSetAndGetRotationInstancePolicyEnabled tests the methods that update and retrieve dual auth instance policy
-func TestSetAndGetRotationInstancePolicyEnabled(t *testing.T) {
+// TestSetAndGetRotationInstancePolicy tests the methods that update and retrieve rotation instance policy
+func TestSetAndGetRotationInstancePolicy(t *testing.T) {
 	defer gock.Off()
 
 	// rotationInstancePolicyRequest := map[string]interface{}{
@@ -1797,7 +1797,7 @@ func TestSetAndGetRotationInstancePolicyEnabled(t *testing.T) {
 
 	gock.New("http://example.com").
 		Put("/instance/policies").
-		MatchParam("policy", RotationInstancePolicy).
+		MatchParam("policy", RotationPolicy).
 		Reply(204)
 
 	intervalMonth := 3
@@ -1807,7 +1807,7 @@ func TestSetAndGetRotationInstancePolicyEnabled(t *testing.T) {
 
 	gock.New("http://example.com").
 		Get("/instance/policies").
-		MatchParam("policy", RotationInstancePolicy).
+		MatchParam("policy", RotationPolicy).
 		Reply(200).
 		Body(bytes.NewReader(rotationInstancePolicyResponse))
 
@@ -1815,16 +1815,11 @@ func TestSetAndGetRotationInstancePolicyEnabled(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, rotation)
-	assert.Equal(t, rotation.PolicyType, RotationInstancePolicy)
+	assert.Equal(t, rotation.PolicyType, RotationPolicy)
 	assert.True(t, *(rotation.PolicyData.Enabled))
 	assert.Equal(t, intervalMonth, *rotation.PolicyData.Attributes.IntervalMonth)
 
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
-}
-
-// TestSetAndGetRotationInstancePolicyDisabled tests the methods that update and retrieve dual auth instance policy
-func TestSetAndGetRotationInstancePolicyDisabled(t *testing.T) {
-	defer gock.Off()
 
 	// rotationInstancePolicyRequest := map[string]interface{}{
 	// 	"metadata": map[string]interface{}{
@@ -1841,7 +1836,7 @@ func TestSetAndGetRotationInstancePolicyDisabled(t *testing.T) {
 	// 	},
 	// }
 
-	rotationInstancePolicyResponse := []byte(`{
+	rotationInstancePolicyResponse = []byte(`{
 		"metadata":{
 			"collectionType":"application/vnd.ibm.kms.policy+json",
 			"collectionTotal":1
@@ -1860,32 +1855,30 @@ func TestSetAndGetRotationInstancePolicyDisabled(t *testing.T) {
 		]
 	}`)
 
-	c, _, err := NewTestClient(t, nil)
 	gock.InterceptClient(&c.HttpClient)
 	defer gock.RestoreClient(&c.HttpClient)
 	c.tokenSource = &FakeTokenSource{}
 
 	gock.New("http://example.com").
 		Put("/instance/policies").
-		MatchParam("policy", RotationInstancePolicy).
+		MatchParam("policy", RotationPolicy).
 		Reply(204)
 
-	intervalMonth := 3
-	err = c.SetRotationInstancePolicy(context.Background(), false, &intervalMonth)
+	err = c.SetRotationInstancePolicy(context.Background(), false, nil)
 
 	assert.NoError(t, err)
 
 	gock.New("http://example.com").
 		Get("/instance/policies").
-		MatchParam("policy", RotationInstancePolicy).
+		MatchParam("policy", RotationPolicy).
 		Reply(200).
 		Body(bytes.NewReader(rotationInstancePolicyResponse))
 
-	rotation, err := c.GetRotationInstancePolicy(context.Background())
+	rotation, err = c.GetRotationInstancePolicy(context.Background())
 
 	assert.NoError(t, err)
 	assert.NotNil(t, rotation)
-	assert.Equal(t, rotation.PolicyType, RotationInstancePolicy)
+	assert.Equal(t, rotation.PolicyType, RotationPolicy)
 	assert.False(t, *(rotation.PolicyData.Enabled))
 
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
@@ -2464,7 +2457,7 @@ func TestSetRotationInstancePolicyError(t *testing.T) {
 
 	gock.New("http://example.com").
 		Put("/api/v2/instance/policies").
-		MatchParam("policy", RotationInstancePolicy).
+		MatchParam("policy", RotationPolicy).
 		Reply(400).
 		Body(bytes.NewReader(errorResponse))
 

--- a/kp_test.go
+++ b/kp_test.go
@@ -1784,7 +1784,8 @@ func TestSetAndGetRotationInstancePolicyEnabled(t *testing.T) {
 		MatchParam("policy", RotationInstancePolicy).
 		Reply(204)
 
-	err = c.SetRotationInstancePolicy(context.Background(), true, 3)
+	intervalMonth := 3
+	err = c.SetRotationInstancePolicy(context.Background(), true, &intervalMonth)
 
 	assert.NoError(t, err)
 
@@ -1800,7 +1801,7 @@ func TestSetAndGetRotationInstancePolicyEnabled(t *testing.T) {
 	assert.NotNil(t, rotation)
 	assert.Equal(t, rotation.PolicyType, RotationInstancePolicy)
 	assert.True(t, *(rotation.PolicyData.Enabled))
-	assert.Equal(t, 3, *rotation.PolicyData.Attributes.IntervalMonth)
+	assert.Equal(t, intervalMonth, *rotation.PolicyData.Attributes.IntervalMonth)
 
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
 }
@@ -1853,7 +1854,8 @@ func TestSetAndGetRotationInstancePolicyDisabled(t *testing.T) {
 		MatchParam("policy", RotationInstancePolicy).
 		Reply(204)
 
-	err = c.SetRotationInstancePolicy(context.Background(), false, 3)
+	intervalMonth := 3
+	err = c.SetRotationInstancePolicy(context.Background(), false, &intervalMonth)
 
 	assert.NoError(t, err)
 
@@ -1869,7 +1871,6 @@ func TestSetAndGetRotationInstancePolicyDisabled(t *testing.T) {
 	assert.NotNil(t, rotation)
 	assert.Equal(t, rotation.PolicyType, RotationInstancePolicy)
 	assert.False(t, *(rotation.PolicyData.Enabled))
-	//assert.Equal(t, 3, *rotation.PolicyData.Attributes.IntervalMonth)
 
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
 }
@@ -2456,7 +2457,8 @@ func TestSetRotationInstancePolicyError(t *testing.T) {
 	defer gock.RestoreClient(&c.HttpClient)
 	c.tokenSource = &FakeTokenSource{}
 
-	err = c.SetRotationInstancePolicy(context.Background(), true, 13)
+	intervalMonth := 13
+	err = c.SetRotationInstancePolicy(context.Background(), true, &intervalMonth)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "INVALID_FIELD_ERR")

--- a/policy.go
+++ b/policy.go
@@ -23,8 +23,6 @@ import (
 
 const (
 	policyType = "application/vnd.ibm.kms.policy+json"
-
-	RotationPolicy = "rotation"
 )
 
 // Policy represents a policy as returned by the KP API.

--- a/policy.go
+++ b/policy.go
@@ -22,6 +22,12 @@ import (
 )
 
 const (
+	// DualAuthDelete defines the policy type as dual auth delete
+	DualAuthDelete = "dualAuthDelete"
+
+	//RotationPolicy defines the policy type as rotation
+	RotationPolicy = "rotation"
+
 	policyType = "application/vnd.ibm.kms.policy+json"
 )
 


### PR DESCRIPTION
This PR is about adding the rotation instance policy in go-sdk.

