### PR TITLE
CreateKeyWithPolicyOverrides go-sdk changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,31 @@ fmt.Println(key.ID, key.Name)
 crkID := key.ID
 ```
 
+### Generating a root key with policy overrides (CRK)
+
+```go
+enable := true
+// Specify policy data
+policy := kp.Policy{
+  Rotation: &kp.Rotation{
+      Enabled: &enable
+			Interval: 3,
+	},
+  DualAuth: &kp.DualAuth{
+    Enabled: &enable,
+  },
+}
+
+// Create a root key named MyRootKey with a rotation and a dualAuthDelete policy
+key, err := client.CreateRootKeyWithPolicyOverrides(ctx, "MyRootKey", nil, nil, policy)
+if err != nil {
+    fmt.Println(err)
+}
+fmt.Println(key.ID, key.Name)
+
+crkID := key.ID
+```
+
 ### Wrapping and Unwrapping a DEK using a specific Root Key.
 
 ```go

--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ enable := true
 // Specify policy data
 policy := kp.Policy{
   Rotation: &kp.Rotation{
-      Enabled: &enable
-			Interval: 3,
-	},
+    Enabled:  &enable,
+    Interval: 3,
+  },
   DualAuth: &kp.DualAuth{
-    Enabled: &enable,
+    Enabled:  &enable,
   },
 }
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -369,13 +369,24 @@ func TestCreateKeyWithPolicyOverrides(t *testing.T) {
 		},
 	})
 	assert.NoError(err)
-	assert.NotNil(crk2.Rotation)
-	assert.EqualValues(crk2.Rotation.Interval, intervalMonth)
+
+	// Fetching rotation key policies for the above created key
+	// and assert rotation policy and interval month change
+	policy, err = c.GetRotationPolicy(ctx, crk2.ID)
+	assert.NoError(err)
+	assert.NotNil(policy.Rotation)
+	assert.EqualValues(policy.Rotation.Interval, intervalMonth)
 
 	// Creating a key with policy overrides with no policies
 	crk3, err := c.CreateRootKeyWithPolicyOverrides(ctx, "rootKeyWithPolicyOverrides", nil, nil, Policy{})
 	assert.NoError(err)
-	assert.Nil(crk3.Rotation)
+
+	// Fetching rotation key policies for the above created key
+	// and assert no rotation policy
+	policy, err = c.GetRotationPolicy(ctx, crk3.ID)
+	assert.NoError(err)
+	assert.Nil(policy.Rotation)
+	assert.EqualValues(policy.Rotation.Interval, intervalMonth)
 
 	// deleting the keys
 	_, err = c.DeleteKey(ctx, crk1.ID, 0)

--- a/keys.go
+++ b/keys.go
@@ -238,9 +238,6 @@ func (c *Client) createKeyResource(ctx context.Context, key Key, path string) (*
 	if err != nil {
 		return nil, err
 	}
-	if path == keysWithPolicyOverridesPath {
-		req.Header.Set("Prefer", preferHeaders[ReturnRepresentation])
-	}
 	keysResponse := Keys{}
 	if _, err := c.do(ctx, req, &keysResponse); err != nil {
 		return nil, err

--- a/keys.go
+++ b/keys.go
@@ -276,6 +276,19 @@ func (c *Client) SetKeyRing(ctx context.Context, idOrAlias, newKeyRingID string)
 	return &response.Keys[0], nil
 }
 
+// CreateImportedKeyWithPolicyOverridesWithSHA1 creates a new KP key with policy overrides from the given key material
+// and key policy details using RSAES OAEP SHA 1 as encryption algorithm.
+func (c *Client) CreateImportedKeyWithPolicyOverridesWithSHA1(ctx context.Context, name string, expiration *time.Time, payload, encryptedNonce, iv string, extractable bool, aliases []string, policy Policy) (*Key, error) {
+	/*
+	 Setting the value of rotationInterval to -1 in case user passes 0 value as we want to retain the param `interval_month` after marshalling so that we can get correct error msg from REST API saying interval_month should be between 1 to 12 Otherwise the param would not be sent to REST API in case of value 0 and it would throw error saying interval_month is missing
+	*/
+	if policy.Rotation != nil && policy.Rotation.Interval == 0 {
+		policy.Rotation.Interval = -1
+	}
+	key := c.createKeyTemplate(ctx, name, expiration, payload, encryptedNonce, iv, extractable, aliases, AlgorithmRSAOAEP1, &policy)
+	return c.createKeyWithPolicyOverrides(ctx, key)
+}
+
 // CreateKeyWithPolicyOverrides creates a new KP key with given key policy details
 func (c *Client) CreateKeyWithPolicyOverrides(ctx context.Context, name string, expiration *time.Time, extractable bool, aliases []string, policy Policy) (*Key, error) {
 	return c.CreateImportedKeyWithPolicyOverrides(ctx, name, expiration, "", "", "", extractable, aliases, policy)

--- a/kp_test.go
+++ b/kp_test.go
@@ -878,6 +878,21 @@ func TestKeyWithPolicyOverrides(t *testing.T) {
 		},
 	}
 
+	testImportedKeyWithPoliciesSHA1 := &Keys{
+		Metadata: KeysMetadata{
+			CollectionType: "json",
+			NumberOfKeys:   1,
+		},
+		Keys: []Key{
+			Key{
+				ID:                  testKeyID,
+				Name:                "Key",
+				Extractable:         false,
+				EncryptionAlgorithm: AlgorithmRSAOAEP1,
+			},
+		},
+	}
+
 	testImportedRootKeyWithPolicies := &Keys{
 		Metadata: keysMetadata,
 		Keys: []Key{
@@ -945,6 +960,7 @@ func TestKeyWithPolicyOverrides(t *testing.T) {
 				MockAuthURL(keyWithPolicyOverridesURL, http.StatusCreated, testImportedRootKeyWithPolicies)
 				MockAuthURL(keyWithPolicyOverridesURL, http.StatusCreated, testGenRootKeyWithPolicies)
 				MockAuthURL(keyWithPolicyOverridesURL, http.StatusCreated, testImportedRootKeyWithPolicies)
+				MockAuthURL(keyWithPolicyOverridesURL, http.StatusCreated, testImportedKeyWithPoliciesSHA1)
 
 				// Non-imported Root Key
 				_, err := api.CreateRootKeyWithPolicyOverrides(ctx, "test", nil, aliases, allPolicies)
@@ -969,6 +985,10 @@ func TestKeyWithPolicyOverrides(t *testing.T) {
 				// Imported Key
 				_, err = api.CreateImportedKeyWithPolicyOverrides(ctx, "test", nil, payload, "", "", false, aliases, Policy{DualAuth: daPolicy})
 				assert.NoError(t, err)
+
+				importedKey, err := api.CreateImportedKeyWithPolicyOverridesWithSHA1(ctx, "Key", nil, "payload", "encryptedNonce", "iv", false, nil, Policy{})
+				assert.NoError(t, err)
+				assert.Equal(t, AlgorithmRSAOAEP1, importedKey.EncryptionAlgorithm)
 
 				return nil
 			},

--- a/kp_test.go
+++ b/kp_test.go
@@ -947,43 +947,28 @@ func TestKeyWithPolicyOverrides(t *testing.T) {
 				MockAuthURL(keyWithPolicyOverridesURL, http.StatusCreated, testImportedRootKeyWithPolicies)
 
 				// Non-imported Root Key
-				key, err := api.CreateRootKeyWithPolicyOverrides(ctx, "test", nil, aliases, allPolicies)
+				_, err := api.CreateRootKeyWithPolicyOverrides(ctx, "test", nil, aliases, allPolicies)
 				assert.NoError(t, err)
-				assert.Equal(t, enableTrue, *key.Rotation.Enabled)
-				assert.Equal(t, 3, key.Rotation.Interval)
-				assert.Equal(t, enableTrue, *key.DualAuthDelete.Enabled)
 
 				// Non-imported Standard Key
-				key, err = api.CreateStandardKeyWithPolicyOverrides(ctx, "", nil, aliases, Policy{DualAuth: daPolicy})
+				_, err = api.CreateStandardKeyWithPolicyOverrides(ctx, "", nil, aliases, Policy{DualAuth: daPolicy})
 				assert.NoError(t, err)
-				assert.Nil(t, key.Rotation)
-				assert.Equal(t, enableTrue, *key.DualAuthDelete.Enabled)
 
 				// Imported Standard Key
-				key, err = api.CreateImportedStandardKeyWithPolicyOverrides(ctx, "", nil, payload, aliases, Policy{DualAuth: daPolicy})
+				_, err = api.CreateImportedStandardKeyWithPolicyOverrides(ctx, "", nil, payload, aliases, Policy{DualAuth: daPolicy})
 				assert.NoError(t, err)
-				assert.Nil(t, key.Rotation)
-				assert.Equal(t, enableTrue, *key.DualAuthDelete.Enabled)
 
 				// Imported Root Key
-				key, err = api.CreateImportedRootKeyWithPolicyOverrides(ctx, "test", nil, payload, "abc", "", aliases, Policy{DualAuth: daPolicy})
+				_, err = api.CreateImportedRootKeyWithPolicyOverrides(ctx, "test", nil, payload, "abc", "", aliases, Policy{DualAuth: daPolicy})
 				assert.NoError(t, err)
-				assert.Nil(t, key.Rotation)
-				assert.Equal(t, enableTrue, *key.DualAuthDelete.Enabled)
 
 				// Non-imported Key
-				key, err = api.CreateKeyWithPolicyOverrides(ctx, "test", nil, false, aliases, allPolicies)
+				_, err = api.CreateKeyWithPolicyOverrides(ctx, "test", nil, false, aliases, allPolicies)
 				assert.NoError(t, err)
-				assert.NotNil(t, key.Rotation)
-				assert.Equal(t, 3, key.Rotation.Interval)
-				assert.Equal(t, enableTrue, *key.Rotation.Enabled)
-				assert.Equal(t, enableTrue, *key.DualAuthDelete.Enabled)
 
 				// Imported Key
-				key, err = api.CreateImportedKeyWithPolicyOverrides(ctx, "test", nil, payload, "", "", false, aliases, Policy{DualAuth: daPolicy})
+				_, err = api.CreateImportedKeyWithPolicyOverrides(ctx, "test", nil, payload, "", "", false, aliases, Policy{DualAuth: daPolicy})
 				assert.NoError(t, err)
-				assert.Nil(t, key.Rotation)
-				assert.Equal(t, enableTrue, *key.DualAuthDelete.Enabled)
 
 				return nil
 			},
@@ -993,7 +978,7 @@ func TestKeyWithPolicyOverrides(t *testing.T) {
 			func(t *testing.T, api *API, ctx context.Context) error {
 				MockAuthURL(keyWithPolicyOverridesURL, http.StatusBadRequest, errorString)
 				// Non-imported Standard Key with rotation policy should throw error
-				_, err := api.CreateStandardKeyWithPolicyOverrides(ctx, "", nil, aliases, Policy{Rotation: rotPolicy})
+				_, err := api.CreateStandardKeyWithPolicyOverrides(ctx, "test", nil, aliases, Policy{Rotation: rotPolicy})
 				assert.Error(t, err)
 				return nil
 			},


### PR DESCRIPTION
**Title**: CreateKeyWithPolicyOverrides go-sdk changes

**Description**: Add support for CreateKeyWithPolicyOverrides API along with changes in test and README.md files.

**Issue/Task Reference**: [kms/kmk/issues/1331](https://github.ibm.com/kms/kmk/issues/1331)