### PR TITLE
Ran detect-Secrets

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,396 @@
+{
+  "exclude": {
+    "files": "^.secrets.baseline$",
+    "lines": null
+  },
+  "generated_at": "2022-08-12T06:22:02Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "README.md": [
+      {
+        "hashed_secret": "93fcbf4c3221f6e6fc21e07ec6e87ad94e60bd26",
+        "is_verified": false,
+        "line_number": 35,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "example_cycle_test.go": [
+      {
+        "hashed_secret": "f75b33f87ffeacb3a4f793a09693e672e07449ff",
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "example_test.go": [
+      {
+        "hashed_secret": "e80b5f30389f2162470fe780e27b90146e5fb0ca",
+        "is_verified": false,
+        "line_number": 81,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "75d5cc62475c1ed3db14215d819514749ae25f53",
+        "is_verified": false,
+        "line_number": 181,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "go.sum": [
+      {
+        "hashed_secret": "e7d2b52449737744aa82f66895db6409dd7efc89",
+        "is_verified": false,
+        "line_number": 2,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4dbbe18874344f8a812138c0c9b17841a5fab11d",
+        "is_verified": false,
+        "line_number": 3,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "a1a8a5e0eb58de033e1642fc200f2de46b8d8bd2",
+        "is_verified": false,
+        "line_number": 6,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1959a795aa93723114b9d0624eb25146709b50a0",
+        "is_verified": false,
+        "line_number": 7,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "fa18cc84565465dca871aa0285736fa8f1c2db75",
+        "is_verified": false,
+        "line_number": 8,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ddd04086256b6596d5678dc919e1018bc7baed6f",
+        "is_verified": false,
+        "line_number": 9,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "84d721026fb8491115d90eb3fe8d30cf71cfea4f",
+        "is_verified": false,
+        "line_number": 10,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "408f026f7bf9ac4f0644b90cabd113a3e79c605b",
+        "is_verified": false,
+        "line_number": 11,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "414595b656b3c65f63b792e39947037efe1517b9",
+        "is_verified": false,
+        "line_number": 12,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "af85b4028a19e55bbcf0e736edbde8ef0f9c62ed",
+        "is_verified": false,
+        "line_number": 13,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bb33ab9838536d2db0b18a72c5c28a0f941213de",
+        "is_verified": false,
+        "line_number": 14,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2b9f5352265bd0b6dc6922eedb405d027930eb9b",
+        "is_verified": false,
+        "line_number": 15,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "6a4a1948d9e9978e41ee2d466928b91e8ac5d54b",
+        "is_verified": false,
+        "line_number": 16,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c382813ad978b45fb54312f408087e014b4374eb",
+        "is_verified": false,
+        "line_number": 17,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f16e20544c05634663c76b999b6707da9f0ecbcc",
+        "is_verified": false,
+        "line_number": 18,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8d19507fdd8eb2c703e7fea913f2df6ca08b5491",
+        "is_verified": false,
+        "line_number": 19,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5116ad7973b20bf79c82b49cdf34439b0ece7f1f",
+        "is_verified": false,
+        "line_number": 20,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "b46ffd57039b50aecbe806f118fdc296d3f8e6dd",
+        "is_verified": false,
+        "line_number": 21,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "197ab72e93bfd563abee11ef65017dfdf5e5ac00",
+        "is_verified": false,
+        "line_number": 22,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "aa945027601e7b92be504f177761e51cd2fc9293",
+        "is_verified": false,
+        "line_number": 23,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "2557e0548d4437fff80d7ec93a8e86c5b20b0ca8",
+        "is_verified": false,
+        "line_number": 24,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "1261521a40fa4e5e360cb3517e3dfa9d85d23d7a",
+        "is_verified": false,
+        "line_number": 25,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4273f54f815e12a2f90f9399e49b6616ad280e54",
+        "is_verified": false,
+        "line_number": 26,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "d858adb1976228c458c39e2564548b3e2466d8d5",
+        "is_verified": false,
+        "line_number": 27,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "iam/iam.go": [
+      {
+        "hashed_secret": "f75b33f87ffeacb3a4f793a09693e672e07449ff",
+        "is_verified": false,
+        "line_number": 51,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3e4bdbe0b80e63c22b178576e906810777387b50",
+        "is_verified": false,
+        "line_number": 120,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "integration_test.go": [
+      {
+        "hashed_secret": "f75b33f87ffeacb3a4f793a09693e672e07449ff",
+        "is_verified": false,
+        "line_number": 55,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "kp_test.go": [
+      {
+        "hashed_secret": "11634ea6495b17ca913d24b49dca32b40e491dc0",
+        "is_verified": false,
+        "line_number": 44,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9f4ed0cc38e03da4c3caf3d8500e0af69cfaefd3",
+        "is_verified": false,
+        "line_number": 189,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "3e48fe9928e96dde5f50bd5514ccaecc504e378e",
+        "is_verified": false,
+        "line_number": 629,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "90f826b48e4e4832be16dd63237e7aede72ec384",
+        "is_verified": false,
+        "line_number": 1594,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0599eac7c4ebc38a9fb5407c1cee19877850ff78",
+        "is_verified": false,
+        "line_number": 2984,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4a8f6f853d71b777faef1c0f50d59df808f377a7",
+        "is_verified": false,
+        "line_number": 3489,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "8ee338cf3361b4fbd663c51393c44ea685e7e31b",
+        "is_verified": false,
+        "line_number": 3490,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7200008cccd3ebe5eb314c7ce57bbe95113e11ff",
+        "is_verified": false,
+        "line_number": 3525,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "7056dab9fea569e2fcb5122c763bfe90d3fa8204",
+        "is_verified": false,
+        "line_number": 3994,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "54b1ab73986eecb14a1839184e4b51ce9668b35e",
+        "is_verified": false,
+        "line_number": 4039,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "policy.go": [
+      {
+        "hashed_secret": "6a361a4e087eab69b48211aecc712bdc3403b2eb",
+        "is_verified": false,
+        "line_number": 290,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.50.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}


### PR DESCRIPTION
As part of “IBM Cloud 3Q2022: FS-IA readiness”, all the IBM/KMS repositories must enable “Detect Secrets” tool [detect secrets](https://w3.ibm.com/w3publisher/detect-secrets), also scan and audit the secrets in their repositories before **8/21/2022**.

In this PR I’ve enabled “detect-secrets” and also scanned this repository. The results are in file `.secrets.baseline`. 

I request that the team audit the potential secrets discovered in this scan.

## Action to take by any contributor of this repo before merging 

 - [ ] Locally, install [detect secret](https://w3.ibm.com/w3publisher/detect-secrets)
 - [ ] Pull this branch
 - [ ] Run detect secret audit on the secrets
 - [ ] Push results to repo

The setup should be quick. The audit itself will take only a few minutes on each repo or maybe 10 minutes on a very large repo.

Installation of secret detect is quick, but there is also a docker method available if you have docker desktop that takes no setup ([Using docker to run detect secrets](https://github.ibm.com/Whitewater/whitewater-detect-secrets/wiki/Developer-Tool-FAQs#docker-setup)).

For further info on detect-secrets please visit: https://w3.ibm.com/w3publisher/detect-secrets/developer-tool

FYI : Henry Grantham, Dinesh Venkatraman
Thanks