### PR TITLE
Support disabling of key rotation policy in KP Go SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,9 +234,9 @@ fmt.Println(keys)
 ### Fetching List Key In Sorted Descending Order Based On Paramaeters.
 
 ```go
-srtStr, _ := GetKeySortStr(WithCreationDateDesc(), WithImportedDesc())
+srtStr, _ := kp.GetKeySortStr(WithCreationDateDesc(), WithImportedDesc())
 
-listKeysOptions := &ListKeysOptions{
+listKeysOptions := &kp.ListKeysOptions{
   Sort: srtStr,
 }
 
@@ -287,3 +287,50 @@ if err != nil {
 fmt.Println(rotationInstancePolicy)
 ```
 
+### Set Key Rotation Policy
+
+#### Without Enabled param
+
+```go
+
+rotationInterval := 3
+keyRotationPolicy, err := client.SetRotationPolicy(context.Background(), "key_id_or_alias", rotationInterval)
+if err != nil {
+  fmt.Println(err)
+}
+fmt.Println(keyRotationPolicy)
+```
+#### With Enabled param
+
+```go
+
+rotationInterval := 3
+enabled := true
+keyRotationPolicy, err := client.SetRotationPolicy(context.Background(), "key_id_or_alias", rotationInterval, enabled)
+if err != nil {
+  fmt.Println(err)
+}
+fmt.Println(keyRotationPolicy)
+```
+
+### Enable Key Rotation Policy
+
+```go
+
+keyRotationPolicy, err := client.EnableRotationPolicy(context.Background(), "key_id_or_alias")
+if err != nil {
+  fmt.Println(err)
+}
+fmt.Println(keyRotationPolicy)
+```
+
+### Disable Key Rotation Policy
+
+```go
+
+keyRotationPolicy, err := client.DisableRotationPolicy(context.Background(), "key_id_or_alias")
+if err != nil {
+  fmt.Println(err)
+}
+fmt.Println(keyRotationPolicy)
+```

--- a/integration_test.go
+++ b/integration_test.go
@@ -294,3 +294,45 @@ func TestRotationInstancePolicy(t *testing.T) {
 	assert.NoError(err)
 
 }
+
+func TestKeyRotationPolicy(t *testing.T) {
+	assert := assert.New(t)
+
+	c, err := NewIntegrationTestClient(t)
+	assert.NoError(err)
+
+	ctx := context.Background()
+
+	// Creating a key
+	key, err := c.CreateKey(ctx, "root", nil, false)
+	assert.NoError(err)
+	keyID := key.ID
+
+	keyPolicies, err := c.GetPolicies(ctx, keyID)
+	assert.NoError(err)
+	assert.EqualValues(0, len(keyPolicies))
+
+	keyRotaionPolicy, err := c.SetRotationPolicy(ctx, keyID, 3, false)
+	assert.NoError(err)
+	assert.NotNil(keyRotaionPolicy)
+
+	keyRotaionPolicy, err = c.GetRotationPolicy(ctx, keyID)
+	assert.NoError(err)
+	assert.NotNil(keyRotaionPolicy)
+	assert.False(*keyRotaionPolicy.Rotation.Enabled)
+	assert.EqualValues(3, keyRotaionPolicy.Rotation.Interval)
+
+	keyRotaionPolicy, err = c.EnableRotationPolicy(ctx, keyID)
+	assert.NoError(err)
+	assert.NotNil(keyRotaionPolicy)
+
+	keyRotaionPolicy, err = c.GetRotationPolicy(ctx, keyID)
+	assert.NoError(err)
+	assert.NotNil(keyRotaionPolicy)
+	assert.True(*keyRotaionPolicy.Rotation.Enabled)
+	assert.EqualValues(3, keyRotaionPolicy.Rotation.Interval)
+
+	// deleting the keys
+	_, err = c.DeleteKey(ctx, keyID, 0)
+	assert.NoError(err)
+}

--- a/kp_test.go
+++ b/kp_test.go
@@ -2490,7 +2490,7 @@ func TestSetKeyPolicies(t *testing.T) {
 				"id":"er482407-6e3c-4f14-56b5-caceadd",
 				"crn":"crn:v5:dummy-env:dummy-service:dummy-region:dummy-details::",
 				"rotation":{
-				"interval_month":6
+					"interval_month":6
 				},
 				"createdBy":"test_user3",
 				"creationDate":"2020-05-07T21:52:22Z",
@@ -2568,10 +2568,10 @@ func TestSetKeyPolicies(t *testing.T) {
 
 	gock.New("http://example.com").
 		Put("/api/v2/keys/"+testKey+"/policies").
-		MatchParam("policy", "rotation").
+		MatchParam("policy", RotationPolicy).
 		Reply(200).Body(bytes.NewReader(rotationPolicyResponse))
 
-	rotationPolicy, err := c.SetRotationPolicy(context.Background(), testKey, 4)
+	rotationPolicy, err := c.SetRotationPolicy(context.Background(), testKey, 6)
 	assert.Nil(t, err)
 	assert.NotNil(t, rotationPolicy)
 	assert.Equal(t, 6, rotationPolicy.Rotation.Interval)
@@ -2599,6 +2599,135 @@ func TestSetKeyPolicies(t *testing.T) {
 	assert.Equal(t, 6, policy.Rotation.Interval)
 
 	assert.True(t, gock.IsDone(), "Expected HTTP requests not called!")
+}
+
+// TestEnabeOrDisableRotationPolicy test the method that enables/disables key rotation policy which makes a request to Key Protect API to enable/disable the rotation key policy
+
+func TestEnabeOrDisableRotationPolicy(t *testing.T) {
+	defer gock.Off()
+	testKey := "2n4y2-4ko2n-4m23f-23j3r"
+	allPoliciesResponse := []byte(`{
+		"metadata":{
+			"collectionType":"application/vnd.ibm.kms.policy+json",
+			"collectionTotal":2
+		},
+		"resources":[
+			{
+				"id":"er482407-6e3c-4f14-56b5-caceadd",
+				"crn":"crn:v5:dummy-env:dummy-service:dummy-region:dummy-details::",
+				"rotation":{
+					"enabled":false,
+					"interval_month":6
+				},
+				"createdBy":"test_user3",
+				"creationDate":"2020-05-07T21:52:22Z",
+				"updatedBy":"test_user3",
+				"lastUpdateDate":"2020-05-08T03:55:52Z"
+			},
+			{
+				"id":"9bfye029-60e2-4cc6-82d7-a900716",
+				"crn":"crn:v5:dummy-env:dummy-service:dummy-region:dummy-details::",
+				"dualAuthDelete":{
+					"enabled":true
+				},
+				"createdBy":"test_user3",
+				"creationDate":"2020-05-07T21:53:51Z",
+				"updatedBy":"test_user3",
+				"lastUpdateDate":"2020-05-07T21:53:51Z"
+			}
+		]
+	}`)
+
+	rotationPolicyResponse := []byte(`{
+		"metadata":{
+			"collectionType":"application/vnd.ibm.kms.policy+json",
+			"collectionTotal":1
+		},
+		"resources":[
+			{
+				"id":"er482407-6e3c-4f14-56b5-caceadd",
+				"crn":"crn:v5:dummy-env:dummy-service:dummy-region:dummy-details::",
+				"rotation":{
+					"enabled":true,
+					"interval_month":6
+				},
+				"createdBy":"test_user3",
+				"creationDate":"2020-05-07T21:52:22Z",
+				"updatedBy":"test_user3",
+				"lastUpdateDate":"2020-05-08T03:55:52Z"
+			}
+		]
+	}`)
+
+	disabledRotationPolicyResponse := []byte(`{
+		"metadata":{
+			"collectionType":"application/vnd.ibm.kms.policy+json",
+			"collectionTotal":1
+		},
+		"resources":[
+			{
+				"id":"er482407-6e3c-4f14-56b5-caceadd",
+				"crn":"crn:v5:dummy-env:dummy-service:dummy-region:dummy-details::",
+				"rotation":{
+					"enabled":false,
+					"interval_month":6
+				},
+				"createdBy":"test_user3",
+				"creationDate":"2020-05-07T21:52:22Z",
+				"updatedBy":"test_user3",
+				"lastUpdateDate":"2020-05-08T03:55:52Z"
+			}
+		]
+	}`)
+
+	c, _, err := NewTestClient(t, nil)
+	gock.InterceptClient(&c.HttpClient)
+	defer gock.RestoreClient(&c.HttpClient)
+	c.tokenSource = &FakeTokenSource{}
+
+	gock.New("http://example.com").
+		Put("/api/v2/keys/"+testKey+"/policies").
+		MatchParam("policy", RotationPolicy).
+		Reply(200).Body(bytes.NewReader(rotationPolicyResponse))
+
+	rotationPolicy, err := c.SetRotationPolicy(context.Background(), testKey, 6, true)
+	assert.Nil(t, err)
+	assert.NotNil(t, rotationPolicy)
+	assert.True(t, *rotationPolicy.Rotation.Enabled)
+	assert.Equal(t, 6, rotationPolicy.Rotation.Interval)
+
+	gock.New("http://example.com").
+		Put("/api/v2/keys/"+testKey+"/policies").
+		MatchParam("policy", RotationPolicy).
+		Reply(200).Body(bytes.NewReader(disabledRotationPolicyResponse))
+
+	rotationPolicy, err = c.DisableRotationPolicy(context.Background(), testKey)
+	assert.Nil(t, err)
+	assert.NotNil(t, rotationPolicy)
+	assert.False(t, *rotationPolicy.Rotation.Enabled)
+	assert.Equal(t, 6, rotationPolicy.Rotation.Interval)
+
+	gock.New("http://example.com").
+		Put("/api/v2/keys/"+testKey+"/policies").
+		MatchParam("policy", RotationPolicy).
+		Reply(200).Body(bytes.NewReader(rotationPolicyResponse))
+
+	rotationPolicy, err = c.EnableRotationPolicy(context.Background(), testKey)
+	assert.Nil(t, err)
+	assert.NotNil(t, rotationPolicy)
+	assert.True(t, *rotationPolicy.Rotation.Enabled)
+	assert.Equal(t, 6, rotationPolicy.Rotation.Interval)
+
+	gock.New("http://example.com").
+		Put("/api/v2/keys/" + testKey + "/policies").
+		Reply(200).Body(bytes.NewReader(allPoliciesResponse))
+
+	allpolicies, err := c.SetPolicies(context.Background(), testKey, true, 6, true, true, false)
+	assert.Nil(t, err)
+	assert.NotNil(t, allpolicies)
+	assert.False(t, *(allpolicies[0].Rotation.Enabled))
+	assert.Equal(t, 6, allpolicies[0].Rotation.Interval)
+	assert.True(t, *(allpolicies[1].DualAuth.Enabled))
 }
 
 // TestGetKeyPolicies tests the methods that get key policy method which makes a request to Key Protect end point to retrieve key policies
@@ -4115,7 +4244,6 @@ func TestListKeys(t *testing.T) {
 		Body(bytes.NewReader(listKeyResponse))
 
 	extractable = true
-	fmt.Println(Active)
 	keyStates := []KeyState{KeyState(Active), KeyState(Suspended)}
 	listKeysOptions = &ListKeysOptions{
 		Limit:       &limit,
@@ -4682,7 +4810,6 @@ func TestListKeySearch(t *testing.T) {
 
 	searchStr = "Key16June"
 	srcStr2, _ = GetKeySearchQuery(&searchStr, AddEscape())
-	fmt.Printf("%s\n", *srcStr2)
 
 	listKeysOptions = &ListKeysOptions{
 		Search: srcStr2,

--- a/policy.go
+++ b/policy.go
@@ -44,7 +44,8 @@ type Policy struct {
 }
 
 type Rotation struct {
-	Interval int `json:"interval_month,omitempty"`
+	Enabled  *bool `json:"enabled,omitempty"`
+	Interval int   `json:"interval_month,omitempty"`
 }
 
 type DualAuth struct {
@@ -156,7 +157,7 @@ func (c *Client) getPolicy(ctx context.Context, id, policyType string, policyres
 	return err
 }
 
-// GetRotationPolivy method retrieves rotation policy details of a key
+// GetRotationPolicy method retrieves rotation policy details of a key
 // For more information can refet the Key Protect docs in the link below:
 // https://cloud.ibm.com/docs/key-protect?topic=key-protect-set-rotation-policy#view-rotation-policy-api
 func (c *Client) GetRotationPolicy(ctx context.Context, idOrAlias string) (*Policy, error) {
@@ -211,13 +212,11 @@ func (c *Client) setPolicy(ctx context.Context, idOrAlias, policyType string, po
 	return &policyresponse, nil
 }
 
-// SetRotationPolicy updates the rotation policy associated with a key by specifying key ID  or alias and rotation interval.
-// For more information can refer the Key Protect docs in the link below:
-// https://cloud.ibm.com/docs/key-protect?topic=key-protect-set-rotation-policy#update-rotation-policy-api
-func (c *Client) SetRotationPolicy(ctx context.Context, idOrAlias string, rotationInterval int) (*Policy, error) {
+func (c *Client) setKeyRotationPolicy(ctx context.Context, idOrAlias string, enable *bool, rotationInterval int) (*Policy, error) {
 	policy := Policy{
 		Type: policyType,
 		Rotation: &Rotation{
+			Enabled:  enable,
 			Interval: rotationInterval,
 		},
 	}
@@ -240,6 +239,35 @@ func (c *Client) SetRotationPolicy(ctx context.Context, idOrAlias string, rotati
 	}
 
 	return &policyresponse.Policies[0], nil
+}
+
+func (c *Client) EnableRotationPolicy(ctx context.Context, idOrAlias string) (*Policy, error) {
+	enabled := true
+	return c.setKeyRotationPolicy(ctx, idOrAlias, &enabled, 0)
+}
+
+func (c *Client) DisableRotationPolicy(ctx context.Context, idOrAlias string) (*Policy, error) {
+	enabled := false
+	return c.setKeyRotationPolicy(ctx, idOrAlias, &enabled, 0)
+}
+
+// SetRotationPolicy updates the rotation policy associated with a key by specifying key ID  or alias and rotation interval.
+// For more information can refer the Key Protect docs in the link below:
+// https://cloud.ibm.com/docs/key-protect?topic=key-protect-set-rotation-policy#update-rotation-policy-api
+func (c *Client) SetRotationPolicy(ctx context.Context, idOrAlias string, rotationInterval int, enabled ...bool) (*Policy, error) {
+	/*
+	 Setting the value of rotationInterval to -1 in case user passes 0 value as we want to retain the param `interval_month` after marshalling
+	 so that we can get correct error msg from REST API saying interval_month should be between 1 to 12
+	 Otherwise the param would not be sent to REST API in case of value 0 and it would throw error saying interval_month is missing
+	*/
+	if rotationInterval == 0 {
+		rotationInterval = -1
+	}
+	var enable *bool
+	if enabled != nil {
+		enable = &enabled[0]
+	}
+	return c.setKeyRotationPolicy(ctx, idOrAlias, enable, rotationInterval)
 }
 
 // SetDualAuthDeletePolicy updates the dual auth delete policy by passing the key ID  or alias and enable detail
@@ -277,12 +305,25 @@ func (c *Client) SetDualAuthDeletePolicy(ctx context.Context, idOrAlias string, 
 // To set rotation policy for the key pass the setRotationPolicy parameter as true and set the rotationInterval detail.
 // To set dual auth delete policy for the key pass the setDualAuthDeletePolicy parameter as true and set the dualAuthEnable detail.
 // Both the policies can be set or either of the policies can be set.
-func (c *Client) SetPolicies(ctx context.Context, idOrAlias string, setRotationPolicy bool, rotationInterval int, setDualAuthDeletePolicy, dualAuthEnable bool) ([]Policy, error) {
+func (c *Client) SetPolicies(ctx context.Context, idOrAlias string, setRotationPolicy bool, rotationInterval int, setDualAuthDeletePolicy, dualAuthEnable bool, rotationEnable ...bool) ([]Policy, error) {
+	/*
+	 Setting the value of rotationInterval to -1 in case user passes 0 value as we want to retain the param `interval_month` after marshalling
+	 so that we can get correct error msg from REST API saying interval_month should be between 1 to 12
+	 Otherwise the param would not be sent to REST API in case of value 0 and it would throw error saying interval_month is missing
+	*/
+	if rotationInterval == 0 {
+		rotationInterval = -1
+	}
+	var enable *bool
+	if rotationEnable != nil {
+		enable = &rotationEnable[0]
+	}
 	policies := []Policy{}
 	if setRotationPolicy {
 		rotationPolicy := Policy{
 			Type: policyType,
 			Rotation: &Rotation{
+				Enabled:  enable,
 				Interval: rotationInterval,
 			},
 		}


### PR DESCRIPTION
**Title:** Add enabled param for key rotation policy in Go SDK

**Issue/Task Reference:** https://github.ibm.com/kms/kmk/issues/1345