### PR TITLE
Detect secrets

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-08-18T10:16:28Z",
+  "generated_at": "2022-09-26T12:21:08Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -83,6 +83,14 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 35,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "0b60828897517e2b8013af62b288e055bf0d095d",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 126,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -169,10 +177,26 @@
         "verified_result": null
       },
       {
+        "hashed_secret": "1db0b23a23282227489c79a9fd31998add2b66f5",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 863,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f7f8eb2ffbd249e8c0e2ce429466c04a6342318b",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 986,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "90f826b48e4e4832be16dd63237e7aede72ec384",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1594,
+        "line_number": 1800,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -180,7 +204,7 @@
         "hashed_secret": "0599eac7c4ebc38a9fb5407c1cee19877850ff78",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2984,
+        "line_number": 3514,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -188,7 +212,7 @@
         "hashed_secret": "4a8f6f853d71b777faef1c0f50d59df808f377a7",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3489,
+        "line_number": 4019,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -196,7 +220,7 @@
         "hashed_secret": "8ee338cf3361b4fbd663c51393c44ea685e7e31b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3490,
+        "line_number": 4020,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -204,7 +228,7 @@
         "hashed_secret": "7200008cccd3ebe5eb314c7ce57bbe95113e11ff",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3525,
+        "line_number": 4055,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -212,7 +236,7 @@
         "hashed_secret": "7056dab9fea569e2fcb5122c763bfe90d3fa8204",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3994,
+        "line_number": 4523,
         "type": "Base64 High Entropy String",
         "verified_result": null
       },
@@ -220,7 +244,7 @@
         "hashed_secret": "54b1ab73986eecb14a1839184e4b51ce9668b35e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 4039,
+        "line_number": 4568,
         "type": "Base64 High Entropy String",
         "verified_result": null
       }
@@ -230,13 +254,13 @@
         "hashed_secret": "6a361a4e087eab69b48211aecc712bdc3403b2eb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 290,
+        "line_number": 335,
         "type": "Secret Keyword",
         "verified_result": null
       }
     ]
   },
-  "version": "0.13.1+ibm.50.dss",
+  "version": "0.13.1+ibm.52.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/integration_test.go
+++ b/integration_test.go
@@ -385,8 +385,7 @@ func TestCreateKeyWithPolicyOverrides(t *testing.T) {
 	// and assert no rotation policy
 	policy, err = c.GetRotationPolicy(ctx, crk3.ID)
 	assert.NoError(err)
-	assert.Nil(policy.Rotation)
-	assert.EqualValues(policy.Rotation.Interval, intervalMonth)
+	assert.Nil(policy)
 
 	// deleting the keys
 	_, err = c.DeleteKey(ctx, crk1.ID, 0)


### PR DESCRIPTION
As part of “IBM Cloud 3Q2022: FS-IA readiness”, all the IBM/KMS repositories must enable “Detect Secrets” tool [detect secrets](https://w3.ibm.com/w3publisher/detect-secrets), also scan and audit the secrets in their repositories before 8/21/2022.

In this PR I’ve enabled “detect-secrets” and also scanned and audited this repository. The results are in file .secrets.baseline.

I request that the team audit the potential secrets discovered in this scan.
## Action taken as per [PR](https://github.ibm.com/kms/kmk/issues/1432):

- [x] Locally, install [detect secret](https://w3.ibm.com/w3publisher/detect-secrets)
- [x] Pull this [branch](https://github.com/IBM/keyprotect-go-client/tree/cli-integration)
- [x] Run detect secret audit on the secrets
- [x] Push results to repo

For further info on detect-secrets please visit: https://w3.ibm.com/w3publisher/detect-secrets/developer-tool

FYI : Dinesh Venkatraman
Thanks

I have also fixed a one line bug in the integration_test.go as part of this PR