### PR TITLE
Support for Custom-Header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,47 @@
 language: go
-dist: xenial
+
+dist: bionic
 
 go:
- - 1.17.x
- - 1.18.x
- - 1.19.x
+- 1.17.x
+- 1.18.x
+- 1.19.x
 
 env:
-  - GO111MODULE=on
+  global:
+    - GO111MODULE=on
+
+before_install:
+  - sudo apt-get update
+  - pyenv global 3.8
 
 before_script:
   - GO111MODULE=off go get -u github.com/haya14busa/goverage
 
 install:
   - go build ./...
+  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.49.0
+  - curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
 
 script:
   - $GOPATH/bin/goverage -v -race -coverprofile=cover.out $(go list ./... | grep -v '/vendor|/scripts')
   - go tool cover -func=cover.out
   - go tool cover -html=cover.out -o=cover.html
 
-# FIXME: these scripts don't exist in this repo
-# after_success:
-#   - ./scripts/calculateCoverage.sh
-#   - ./scripts/publishCoverage.sh
+# To enable semantic-release, uncomment these sections.
+before_deploy:
+  - nvm install 14
+  - npm install -g npm@6.x
+  - npm install @semantic-release/changelog
+  - npm install @semantic-release/exec
+  - npm install @semantic-release/git
+  - npm install @semantic-release/github
+  - pip install --user bump2version
+#
+deploy:
+  - provider: script
+    script: npx semantic-release
+    skip_cleanup: true
+    on:
+      go: '1.18.x'
+      branch: master

--- a/README.md
+++ b/README.md
@@ -344,29 +344,29 @@ fmt.Println(keys)
 
 
 1) From ServiceClient (For Every API Call)
-```
+```go
 cc := kp.ClientConfig{
-		BaseURL:    "BASE_URL",
-		APIKey:     "API_KEY",
-		InstanceID: "INSTANCE_ID",
-		Headers: http.Header{
-			"Custom-Header":  {"Custom-Value"},
-		},
-	}
+    BaseURL:    "BASE_URL",
+    APIKey:     "API_KEY",
+    InstanceID: "INSTANCE_ID",
+    Headers: http.Header{
+      "Custom-Header":  {"Custom-Value"},
+    },
+  }
 ```
 
 2) From ServiceCall (Per API Call)
 
 * Define Header just before the API Call and Empty out when done.
 
-```
+```go
 client.Config.Headers = make(http.Header))
 client.Config.Headers.Set("Custom-Header", "Custom-Header-Value")
 
 key, err := client.CreateKey(params)
-	if err != nil {
-		panic(err)
-	}
+  if err != nil {
+    panic(err)
+  }
 
 client.Config.Headers = http.Header{}
 ```

--- a/README.md
+++ b/README.md
@@ -339,3 +339,34 @@ if err != nil {
 }
 fmt.Println(keys)
 ```
+
+### Support for Adding Custom Header
+
+
+1) From ServiceClient (For Every API Call)
+```
+cc := kp.ClientConfig{
+		BaseURL:    "BASE_URL",
+		APIKey:     "API_KEY",
+		InstanceID: "INSTANCE_ID",
+		Headers: http.Header{
+			"Custom-Header":  {"Custom-Value"},
+		},
+	}
+```
+
+2) From ServiceCall (Per API Call)
+
+* Define Header just before the API Call and Empty out when done.
+
+```
+client.Config.Headers = make(http.Header))
+client.Config.Headers.Set("Custom-Header", "Custom-Header-Value")
+
+key, err := client.CreateKey(params)
+	if err != nil {
+		panic(err)
+	}
+
+client.Config.Headers = http.Header{}
+```

--- a/kp.go
+++ b/kp.go
@@ -78,7 +78,7 @@ type ClientConfig struct {
 	KeyRing       string      // The ID of the target Key Ring the key is associated with. It is optional but recommended for better performance.
 	Verbose       int         // See verbose values above
 	Timeout       float64     // KP request timeout in seconds.
-	Headers       http.Header //Support for Custom Header
+	Headers       http.Header // Support for Custom Header
 }
 
 // DefaultTransport ...
@@ -256,7 +256,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, res interface{}) (*h
 	if c.Config.KeyRing != "" {
 		req.Header.Set("x-kms-key-ring", c.Config.KeyRing)
 	}
-
+	// Adding check for Custom Header Input
 	if c.Config.Headers != nil {
 		for key, value := range c.Config.Headers {
 			req.Header.Set(key, strings.Join(value, ","))

--- a/kp.go
+++ b/kp.go
@@ -71,13 +71,14 @@ type ctxKey string
 // ClientConfig ...
 type ClientConfig struct {
 	BaseURL       string
-	Authorization string  // The IBM Cloud (Bluemix) access token
-	APIKey        string  // Service ID API key, can be used instead of an access token
-	TokenURL      string  // The URL used to get an access token from the API key
-	InstanceID    string  // The IBM Cloud (Bluemix) instance ID that identifies your Key Protect service instance.
-	KeyRing       string  // The ID of the target Key Ring the key is associated with. It is optional but recommended for better performance.
-	Verbose       int     // See verbose values above
-	Timeout       float64 // KP request timeout in seconds.
+	Authorization string      // The IBM Cloud (Bluemix) access token
+	APIKey        string      // Service ID API key, can be used instead of an access token
+	TokenURL      string      // The URL used to get an access token from the API key
+	InstanceID    string      // The IBM Cloud (Bluemix) instance ID that identifies your Key Protect service instance.
+	KeyRing       string      // The ID of the target Key Ring the key is associated with. It is optional but recommended for better performance.
+	Verbose       int         // See verbose values above
+	Timeout       float64     // KP request timeout in seconds.
+	Headers       http.Header //Support for Custom Header
 }
 
 // DefaultTransport ...
@@ -254,6 +255,12 @@ func (c *Client) do(ctx context.Context, req *http.Request, res interface{}) (*h
 
 	if c.Config.KeyRing != "" {
 		req.Header.Set("x-kms-key-ring", c.Config.KeyRing)
+	}
+
+	if c.Config.Headers != nil {
+		for key, value := range c.Config.Headers {
+			req.Header.Set(key, strings.Join(value, ","))
+		}
 	}
 
 	// set request up to be retryable on 500-level http codes and client errors


### PR DESCRIPTION
Support for Adding Custom Header.

1) From ServiceClient 
```
cc := kp.ClientConfig{
		BaseURL:    "",
		APIKey:     "",
		InstanceID: "",
		Headers: http.Header{
			"Custom-Header":  {"Custom-Value"},
		},
	}
```

2) From ServiceCall (Per API)

**Define Header just before the API Call and clear it after call**

```
client.Config.Headers = make(http.Header)
	client.Config.Headers.Set("Custom-Header", "Custom-Header-Value")

	key, err := client.CreateKey(context.Background(), "NewKey", nil, true)
	if err != nil {
		panic(err)
	}
	client.Config.Headers = http.Header{}
```