### PR TITLE
Added WrapCreateDEKV2 with KeyVersion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ dek = nil
 ```
 
 Have key protect create a DEK for you:
+* To Get the **keyversion** along with DEK and wrapped DEK use **WrapCreateDEKV2()**
 
 ```go
 dek, wrappedDek, err := client.WrapCreateDEK(ctx, crkIDOrAlias, nil)

--- a/integration_test.go
+++ b/integration_test.go
@@ -108,6 +108,36 @@ func TestWrapUnwrap(t *testing.T) {
 	}
 }
 
+func TestWrapDEKV2UnWrap(t *testing.T) {
+	assert := assert.New(t)
+
+	c, err := NewIntegrationTestClient(t)
+	assert.NoError(err)
+
+	ctx := context.Background()
+
+	crk, err := c.CreateKey(ctx, "kptest-crk", nil, false)
+	assert.NoError(err)
+	t.Logf("CRK created successfully: id=%s\n", crk.ID)
+
+	wrapKeyDetails, err := c.WrapCreateDEKV2(ctx, crk.ID, nil)
+	assert.NoError(err)
+
+	getKeyVersion, err := c.ListKeyVersions(ctx, crk.ID, nil)
+	assert.NoError(err)
+	assert.EqualValues(getKeyVersion.KeyVersion[0].ID, wrapKeyDetails.KeyVersion.ID)
+
+	unwrapped, err := c.Unwrap(ctx, crk.ID, []byte(wrapKeyDetails.CipherText), nil)
+	assert.EqualValues(unwrapped, wrapKeyDetails.PlainText)
+
+	_, err = c.DeleteKey(ctx, crk.ID, 0)
+	if err != nil {
+		t.Logf("Error deleting key: %s\n", err)
+	} else {
+		t.Logf("Key deleted: id=%s\n", crk.ID)
+	}
+}
+
 func TestWrapV2Unwrap(t *testing.T) {
 	assert := assert.New(t)
 

--- a/keys.go
+++ b/keys.go
@@ -555,6 +555,11 @@ func (c *Client) wrap(ctx context.Context, idOrAlias string, plainText []byte, a
 	return pt, ct, nil
 }
 
+// WrapCreateDEKV2 supports KeyVersion details with DEK and WrapDEK
+func (c *Client) WrapCreateDEKV2(ctx context.Context, idOrAlias string, additionalAuthData *[]string) (*KeyActionResponse, error) {
+	return c.WrapV2(ctx, idOrAlias, nil, additionalAuthData)
+}
+
 // WrapWithKeyVersion function supports KeyVersion Details, PlainText and Cyphertext in response
 func (c *Client) WrapV2(ctx context.Context, idOrAlias string, plainText []byte, additionalAuthData *[]string) (*KeyActionResponse, error) {
 	keysActionReq := &KeysActionRequest{}


### PR DESCRIPTION
In reference to this [PR](https://github.com/IBM/keyprotect-go-client/pull/100) supporting KeyVersion in Wrap Response, the support has been added with WrapCreateDEKV2 function as well. This is reagrding the [issue](https://github.ibm.com/kms/kmk/issues/1433)
