### PR TITLE
Fix Logic in Key Create WithPayload

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -151,14 +151,13 @@ func WithDescription(description string) CreateKeyOption {
 func WithPayload(payload string, encryptedNonce, iv *string, sha1 bool) CreateKeyOption {
 	return func(key *Key) {
 		key.Payload = payload
-		if !key.Extractable {
-			if payload != "" {
-				algorithm := AlgorithmRSAOAEP256
-				if sha1 {
-					algorithm = AlgorithmRSAOAEP1
-				}
-				key.EncryptionAlgorithm = algorithm
+		if !key.Extractable && payload != "" {
+			algorithm := AlgorithmRSAOAEP256
+			if sha1 {
+				algorithm = AlgorithmRSAOAEP1
 			}
+			key.EncryptionAlgorithm = algorithm
+
 			if encryptedNonce != nil {
 				key.EncryptedNonce = *encryptedNonce
 			}

--- a/keys.go
+++ b/keys.go
@@ -152,9 +152,12 @@ func WithPayload(payload string, encryptedNonce, iv *string, sha1 bool) CreateKe
 	return func(key *Key) {
 		key.Payload = payload
 		if !key.Extractable {
-			algorithm := AlgorithmRSAOAEP256
-			if sha1 {
-				algorithm = AlgorithmRSAOAEP1
+			if payload != "" {
+				algorithm := AlgorithmRSAOAEP256
+				if sha1 {
+					algorithm = AlgorithmRSAOAEP1
+				}
+				key.EncryptionAlgorithm = algorithm
 			}
 			if encryptedNonce != nil {
 				key.EncryptedNonce = *encryptedNonce
@@ -162,7 +165,6 @@ func WithPayload(payload string, encryptedNonce, iv *string, sha1 bool) CreateKe
 			if iv != nil {
 				key.IV = *iv
 			}
-			key.EncryptionAlgorithm = algorithm
 		}
 	}
 }


### PR DESCRIPTION
There was a minor problem with the key create With payload, such that passing in an empty string payload would cause the key create request to be created with a field for "encryptionAlgorithm", but without a "payload" field. This caused an error in the API.

This can probably be considered `v0.12.1`