### PR TITLE
Retractions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,10 @@ require (
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/h2non/gock.v1 v1.1.2
 )
+
+retract (
+	v0.11.0 // Contains bugs that break create key
+	v0.12.0 // Contains bugs that break create key
+	v0.12.1 // Contains bugs that break create key
+	v0.12.3 // Contains only retractions
+)


### PR DESCRIPTION
Publish this as `v0.12.3` to retract the versions of the SDK that have a broken create key function.
https://go.dev/ref/mod#go-mod-file-retract