### PR TITLE
feat(build): Add KMIP Management APIs to Go SDK

### DIFF
--- a/key_rings.go
+++ b/key_rings.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	path = "key_rings"
+	KeyRingPath = "key_rings"
 )
 
 type KeyRing struct {
@@ -28,7 +28,7 @@ type KeyRings struct {
 // https://cloud.ibm.com/docs/key-protect?topic=key-protect-managing-key-rings#create-key-ring-api
 func (c *Client) CreateKeyRing(ctx context.Context, id string) error {
 
-	req, err := c.newRequest("POST", fmt.Sprintf(path+"/%s", id), nil)
+	req, err := c.newRequest("POST", fmt.Sprintf(KeyRingPath+"/%s", id), nil)
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func (c *Client) CreateKeyRing(ctx context.Context, id string) error {
 // https://cloud.ibm.com/docs/key-protect?topic=key-protect-managing-key-rings#list-key-ring-api
 func (c *Client) GetKeyRings(ctx context.Context) (*KeyRings, error) {
 	rings := KeyRings{}
-	req, err := c.newRequest("GET", path, nil)
+	req, err := c.newRequest("GET", KeyRingPath, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func WithForce(force bool) DeleteKeyRingQueryOption {
 // For information please refer to the link below:
 // https://cloud.ibm.com/docs/key-protect?topic=key-protect-managing-key-rings#delete-key-ring-api
 func (c *Client) DeleteKeyRing(ctx context.Context, id string, opts ...DeleteKeyRingQueryOption) error {
-	req, err := c.newRequest("DELETE", fmt.Sprintf(path+"/%s", id), nil)
+	req, err := c.newRequest("DELETE", fmt.Sprintf(KeyRingPath+"/%s", id), nil)
 	for _, opt := range opts {
 		opt(req)
 	}

--- a/key_rings.go
+++ b/key_rings.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	KeyRingPath = "key_rings"
+	keyRingPath = "key_rings"
 )
 
 type KeyRing struct {
@@ -28,7 +28,7 @@ type KeyRings struct {
 // https://cloud.ibm.com/docs/key-protect?topic=key-protect-managing-key-rings#create-key-ring-api
 func (c *Client) CreateKeyRing(ctx context.Context, id string) error {
 
-	req, err := c.newRequest("POST", fmt.Sprintf(KeyRingPath+"/%s", id), nil)
+	req, err := c.newRequest("POST", fmt.Sprintf(keyRingPath+"/%s", id), nil)
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func (c *Client) CreateKeyRing(ctx context.Context, id string) error {
 // https://cloud.ibm.com/docs/key-protect?topic=key-protect-managing-key-rings#list-key-ring-api
 func (c *Client) GetKeyRings(ctx context.Context) (*KeyRings, error) {
 	rings := KeyRings{}
-	req, err := c.newRequest("GET", KeyRingPath, nil)
+	req, err := c.newRequest("GET", keyRingPath, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func WithForce(force bool) DeleteKeyRingQueryOption {
 // For information please refer to the link below:
 // https://cloud.ibm.com/docs/key-protect?topic=key-protect-managing-key-rings#delete-key-ring-api
 func (c *Client) DeleteKeyRing(ctx context.Context, id string, opts ...DeleteKeyRingQueryOption) error {
-	req, err := c.newRequest("DELETE", fmt.Sprintf(KeyRingPath+"/%s", id), nil)
+	req, err := c.newRequest("DELETE", fmt.Sprintf(keyRingPath+"/%s", id), nil)
 	for _, opt := range opts {
 		opt(req)
 	}

--- a/kmip_mgmt_adapters.go
+++ b/kmip_mgmt_adapters.go
@@ -3,9 +3,9 @@ package kp
 import (
 	"context"
 	"fmt"
+	"time"
 )
 
-// TODO: comments are all wrong
 const (
 	KMIPAdapterPath = "kmip_adapters"
 	kmipAdapterType = "application/vnd.ibm.kms.kmip_adapter+json"
@@ -14,9 +14,13 @@ const (
 type KMIPAdapter struct {
 	ID          string      `json:"id,omitempty"`
 	Profile     string      `json:"profile,omitempty"`
-	ProfileData kmipProfile `json:"profile_data"`
+	ProfileData kmipProfile `json:"profile_data,omitempty"`
 	Name        string      `json:"name,omitempty"`
 	Description string      `json:"description"`
+	CreatedBy   string      `json:"created_by,omitempty"`
+	CreatedAt   *time.Time  `json:"created_at,omitempty"`
+	UpdatedBy   string      `json:"updated_by,omitempty"`
+	UpdatedAt   *time.Time  `json:"updated_at,omitempty"`
 }
 
 type KMIPAdapters struct {

--- a/kmip_mgmt_adapters.go
+++ b/kmip_mgmt_adapters.go
@@ -12,6 +12,7 @@ const (
 )
 
 type KMIPAdapter struct {
+	ID          string      `json:"id,omitempty"`
 	Profile     string      `json:"profile,omitempty"`
 	ProfileData kmipProfile `json:"profile_data"`
 	Name        string      `json:"name,omitempty"`
@@ -40,7 +41,7 @@ const (
 // CreateKMIPAdapter method creates a KMIP Adapter with the specified profile.
 // For information please refer to the link below:
 // https://cloud.ibm.com/docs/key-protect?topic=placeholder
-func (c *Client) CreateKMIPAdapter(ctx context.Context, id string, profile CreateKMIPAdapterProfile, options ...CreateKMIPAdapterOption) (*KMIPAdapter, error) {
+func (c *Client) CreateKMIPAdapter(ctx context.Context, profile CreateKMIPAdapterProfile, options ...CreateKMIPAdapterOption) (*KMIPAdapter, error) {
 	newAdapter := &KMIPAdapter{}
 	profile(newAdapter)
 	for _, opt := range options {

--- a/kmip_mgmt_adapters.go
+++ b/kmip_mgmt_adapters.go
@@ -37,9 +37,9 @@ const (
 // CreateKMIPAdapter method creates a KMIP Adapter with the specified profile.
 // For information please refer to the link below:
 // https://cloud.ibm.com/docs/key-protect?topic=placeholder
-func (c *Client) CreateKMIPAdapter(ctx context.Context, profile CreateKMIPAdapterProfile, options ...CreateKMIPAdapterOption) (*KMIPAdapter, error) {
+func (c *Client) CreateKMIPAdapter(ctx context.Context, profileOpt CreateKMIPAdapterProfile, options ...CreateKMIPAdapterOption) (*KMIPAdapter, error) {
 	newAdapter := &KMIPAdapter{}
-	profile(newAdapter)
+	profileOpt(newAdapter)
 	for _, opt := range options {
 		opt(newAdapter)
 	}

--- a/kmip_mgmt_adapters.go
+++ b/kmip_mgmt_adapters.go
@@ -14,15 +14,15 @@ const (
 )
 
 type KMIPAdapter struct {
-	ID          string      `json:"id,omitempty"`
-	Profile     string      `json:"profile,omitempty"`
-	ProfileData kmipProfile `json:"profile_data,omitempty"`
-	Name        string      `json:"name,omitempty"`
-	Description string      `json:"description"`
-	CreatedBy   string      `json:"created_by,omitempty"`
-	CreatedAt   *time.Time  `json:"created_at,omitempty"`
-	UpdatedBy   string      `json:"updated_by,omitempty"`
-	UpdatedAt   *time.Time  `json:"updated_at,omitempty"`
+	ID          string            `json:"id,omitempty"`
+	Profile     string            `json:"profile,omitempty"`
+	ProfileData KMIPProfileNative `json:"profile_data,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Description string            `json:"description"`
+	CreatedBy   string            `json:"created_by,omitempty"`
+	CreatedAt   *time.Time        `json:"created_at,omitempty"`
+	UpdatedBy   string            `json:"updated_by,omitempty"`
+	UpdatedAt   *time.Time        `json:"updated_at,omitempty"`
 }
 
 type KMIPAdapters struct {
@@ -30,7 +30,7 @@ type KMIPAdapters struct {
 	Adapters []KMIPAdapter `json:"resources"`
 }
 
-type kmipProfile interface {
+type kmipProfileData interface {
 	Type() string
 }
 
@@ -63,7 +63,6 @@ func (c *Client) CreateKMIPAdapter(ctx context.Context, profile CreateKMIPAdapte
 	if err != nil {
 		return nil, err
 	}
-
 	return unwrapKMIPAdapterResp(create_resp), nil
 }
 

--- a/kmip_mgmt_adapters.go
+++ b/kmip_mgmt_adapters.go
@@ -81,7 +81,7 @@ func WithNativeProfile(crkID string) CreateKMIPAdapterProfile {
 	}
 }
 
-func (c *Client) GetKMIPAdapters(ctx context.Context, limit, offset int) (*KMIPAdapters, error) {
+func (c *Client) GetKMIPAdapters(ctx context.Context, limit, offset int, totalCount bool) (*KMIPAdapters, error) {
 	adapters := KMIPAdapters{}
 	req, err := c.newRequest("GET", KMIPAdapterPath, nil)
 	if err != nil {
@@ -91,6 +91,9 @@ func (c *Client) GetKMIPAdapters(ctx context.Context, limit, offset int) (*KMIPA
 	v := url.Values{}
 	v.Set("limit", strconv.Itoa(limit))
 	v.Set("offset", strconv.Itoa(offset))
+	if totalCount {
+		v.Set("totalCount", "true")
+	}
 	req.URL.RawQuery = v.Encode()
 
 	_, err = c.do(ctx, req, &adapters)

--- a/kmip_mgmt_adapters.go
+++ b/kmip_mgmt_adapters.go
@@ -78,8 +78,15 @@ func WithNativeProfile(crkID string) CreateKMIPAdapterProfile {
 	}
 }
 
+type ListKmipAdaptersOptions struct {
+	Limit      *uint32
+	Offset     *uint32
+	TotalCount *bool
+	// CrkID      *string
+}
+
 // GetKMIPAdapters method lists KMIP Adapters associated with a specific KP instance.
-func (c *Client) GetKMIPAdapters(ctx context.Context, listOpts *ListOptions) (*KMIPAdapters, error) {
+func (c *Client) GetKMIPAdapters(ctx context.Context, listOpts *ListKmipAdaptersOptions) (*KMIPAdapters, error) {
 	adapters := KMIPAdapters{}
 	req, err := c.newRequest("GET", kmipAdapterPath, nil)
 	if err != nil {
@@ -97,6 +104,9 @@ func (c *Client) GetKMIPAdapters(ctx context.Context, listOpts *ListOptions) (*K
 		if listOpts.TotalCount != nil {
 			values.Set("totalCount", fmt.Sprint(*listOpts.TotalCount))
 		}
+		// if listOpts.CrkID != nil {
+		// 	values.Set("crk_id", *listOpts.CrkID)
+		// }
 		req.URL.RawQuery = values.Encode()
 	}
 

--- a/kmip_mgmt_adapters.go
+++ b/kmip_mgmt_adapters.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	KMIPAdapterPath = "kmip_adapters"
+	kmipAdapterPath = "kmip_adapters"
 	kmipAdapterType = "application/vnd.ibm.kms.kmip_adapter+json"
 )
 
@@ -33,15 +33,13 @@ const (
 )
 
 // CreateKMIPAdapter method creates a KMIP Adapter with the specified profile.
-// For information please refer to the link below:
-// https://cloud.ibm.com/docs/key-protect?topic=placeholder
 func (c *Client) CreateKMIPAdapter(ctx context.Context, profileOpt CreateKMIPAdapterProfile, options ...CreateKMIPAdapterOption) (*KMIPAdapter, error) {
 	newAdapter := &KMIPAdapter{}
 	profileOpt(newAdapter)
 	for _, opt := range options {
 		opt(newAdapter)
 	}
-	req, err := c.newRequest("POST", KMIPAdapterPath, wrapKMIPAdapter(*newAdapter))
+	req, err := c.newRequest("POST", kmipAdapterPath, wrapKMIPAdapter(*newAdapter))
 	if err != nil {
 		return nil, err
 	}
@@ -54,6 +52,7 @@ func (c *Client) CreateKMIPAdapter(ctx context.Context, profileOpt CreateKMIPAda
 	return unwrapKMIPAdapterResp(create_resp), nil
 }
 
+// Functions to be passed into the CreateKMIPAdapter() method to specify specific fields.
 type CreateKMIPAdapterOption func(*KMIPAdapter)
 type CreateKMIPAdapterProfile func(*KMIPAdapter)
 
@@ -79,9 +78,10 @@ func WithNativeProfile(crkID string) CreateKMIPAdapterProfile {
 	}
 }
 
+// GetKMIPAdapters method lists KMIP Adapters associated with a specific KP instance.
 func (c *Client) GetKMIPAdapters(ctx context.Context, listOpts *ListOptions) (*KMIPAdapters, error) {
 	adapters := KMIPAdapters{}
-	req, err := c.newRequest("GET", KMIPAdapterPath, nil)
+	req, err := c.newRequest("GET", kmipAdapterPath, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -108,9 +108,10 @@ func (c *Client) GetKMIPAdapters(ctx context.Context, listOpts *ListOptions) (*K
 	return &adapters, nil
 }
 
-func (c *Client) GetKMIPAdapter(ctx context.Context, id string) (*KMIPAdapter, error) {
+// GetKMIPAdapter method retrieves a single KMIP Adapter by name or ID.
+func (c *Client) GetKMIPAdapter(ctx context.Context, nameOrID string) (*KMIPAdapter, error) {
 	adapters := KMIPAdapters{}
-	req, err := c.newRequest("GET", fmt.Sprintf("%s/%s", KMIPAdapterPath, id), nil)
+	req, err := c.newRequest("GET", fmt.Sprintf("%s/%s", kmipAdapterPath, nameOrID), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -123,8 +124,9 @@ func (c *Client) GetKMIPAdapter(ctx context.Context, id string) (*KMIPAdapter, e
 	return unwrapKMIPAdapterResp(&adapters), nil
 }
 
-func (c *Client) DeleteKMIPAdapter(ctx context.Context, id string) error {
-	req, err := c.newRequest("DELETE", fmt.Sprintf("%s/%s", KMIPAdapterPath, id), nil)
+// DeletesKMIPAdapter method deletes a single KMIP Adapter by name or ID.
+func (c *Client) DeleteKMIPAdapter(ctx context.Context, nameOrID string) error {
+	req, err := c.newRequest("DELETE", fmt.Sprintf("%s/%s", kmipAdapterPath, nameOrID), nil)
 	if err != nil {
 		return err
 	}

--- a/kmip_mgmt_adapters.go
+++ b/kmip_mgmt_adapters.go
@@ -1,0 +1,145 @@
+package kp
+
+import (
+	"context"
+	"fmt"
+)
+
+// TODO: comments are all wrong
+const (
+	KMIPAdapterPath = "kmip_adapters"
+	kmipAdapterType = "application/vnd.ibm.kms.kmip_adapter+json"
+)
+
+type KMIPAdapter struct {
+	Profile     string      `json:"profile,omitempty"`
+	ProfileData kmipProfile `json:"profile_data"`
+	Name        string      `json:"name,omitempty"`
+	Description string      `json:"description"`
+}
+
+type KMIPAdapters struct {
+	Metadata KeysMetadata  `json:"metadata"`
+	Adapters []KMIPAdapter `json:"resources"`
+}
+
+type kmipProfile interface {
+	Type() string
+}
+
+type KMIPProfileNative struct {
+	CrkID string `json:"crk_id"`
+}
+
+func (k KMIPProfileNative) Type() string { return KMIP_Profile_Native }
+
+const (
+	KMIP_Profile_Native = "native_1.0"
+)
+
+// CreateKMIPAdapter method creates a KMIP Adapter with the specified profile.
+// For information please refer to the link below:
+// https://cloud.ibm.com/docs/key-protect?topic=placeholder
+func (c *Client) CreateKMIPAdapter(ctx context.Context, id string, profile CreateKMIPAdapterProfile, options ...CreateKMIPAdapterOption) (*KMIPAdapter, error) {
+	newAdapter := &KMIPAdapter{}
+	profile(newAdapter)
+	for _, opt := range options {
+		opt(newAdapter)
+	}
+	req, err := c.newRequest("POST", KMIPAdapterPath, wrapKMIPAdapter(*newAdapter))
+	if err != nil {
+		return nil, err
+	}
+
+	create_resp := &KMIPAdapters{}
+	_, err = c.do(ctx, req, create_resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return unwrapKMIPAdapterResp(create_resp), nil
+}
+
+type CreateKMIPAdapterOption func(*KMIPAdapter)
+type CreateKMIPAdapterProfile func(*KMIPAdapter)
+
+func WithKMIPAdapterName(name string) CreateKMIPAdapterOption {
+	return func(adapter *KMIPAdapter) {
+		adapter.Name = name
+	}
+}
+
+func WithKMIPAdapterDescription(description string) CreateKMIPAdapterOption {
+	return func(adapter *KMIPAdapter) {
+		adapter.Description = description
+	}
+}
+
+func WithNativeProfile(crkID string) CreateKMIPAdapterProfile {
+	return func(adapter *KMIPAdapter) {
+		adapter.Profile = KMIP_Profile_Native
+
+		adapter.ProfileData = KMIPProfileNative{
+			CrkID: crkID,
+		}
+	}
+}
+
+func (c *Client) GetKMIPAdapters(ctx context.Context) (*KMIPAdapters, error) {
+	adapters := KMIPAdapters{}
+	req, err := c.newRequest("GET", KMIPAdapterPath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = c.do(ctx, req, &adapters)
+	if err != nil {
+		return nil, err
+	}
+
+	return &adapters, nil
+}
+
+func (c *Client) GetKMIPAdapter(ctx context.Context, id string) (*KMIPAdapter, error) {
+	adapters := KMIPAdapters{}
+	req, err := c.newRequest("GET", fmt.Sprintf("%s/%s", KMIPAdapterPath, id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = c.do(ctx, req, &adapters)
+	if err != nil {
+		return nil, err
+	}
+
+	return &adapters.Adapters[0], nil
+}
+
+func (c *Client) DeleteKMIPAdapter(ctx context.Context, id string) error {
+	req, err := c.newRequest("DELETE", fmt.Sprintf("%s/%s", KMIPAdapterPath, id), nil)
+
+	if err != nil {
+		return err
+	}
+
+	_, err = c.do(ctx, req, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func wrapKMIPAdapter(adapter KMIPAdapter) KMIPAdapters {
+	return KMIPAdapters{
+		Metadata: KeysMetadata{
+			CollectionType: kmipAdapterType,
+			NumberOfKeys:   1,
+		},
+		Adapters: []KMIPAdapter{adapter},
+	}
+}
+
+func unwrapKMIPAdapterResp(resp *KMIPAdapters) *KMIPAdapter {
+	return &resp.Adapters[0]
+}

--- a/kmip_mgmt_adapters.go
+++ b/kmip_mgmt_adapters.go
@@ -26,8 +26,8 @@ type KMIPAdapter struct {
 }
 
 type KMIPAdapters struct {
-	Metadata KeysMetadata  `json:"metadata"`
-	Adapters []KMIPAdapter `json:"resources"`
+	Metadata CollectionMetadata `json:"metadata"`
+	Adapters []KMIPAdapter      `json:"resources"`
 }
 
 const (
@@ -135,9 +135,9 @@ func (c *Client) DeleteKMIPAdapter(ctx context.Context, id string) error {
 
 func wrapKMIPAdapter(adapter KMIPAdapter) KMIPAdapters {
 	return KMIPAdapters{
-		Metadata: KeysMetadata{
-			CollectionType: kmipAdapterType,
-			NumberOfKeys:   1,
+		Metadata: CollectionMetadata{
+			CollectionType:  kmipAdapterType,
+			CollectionTotal: 1,
 		},
 		Adapters: []KMIPAdapter{adapter},
 	}

--- a/kmip_mgmt_adapters.go
+++ b/kmip_mgmt_adapters.go
@@ -3,8 +3,6 @@ package kp
 import (
 	"context"
 	"fmt"
-	"net/url"
-	"strconv"
 	"time"
 )
 
@@ -81,20 +79,26 @@ func WithNativeProfile(crkID string) CreateKMIPAdapterProfile {
 	}
 }
 
-func (c *Client) GetKMIPAdapters(ctx context.Context, limit, offset int, totalCount bool) (*KMIPAdapters, error) {
+func (c *Client) GetKMIPAdapters(ctx context.Context, listOpts *ListOptions) (*KMIPAdapters, error) {
 	adapters := KMIPAdapters{}
 	req, err := c.newRequest("GET", KMIPAdapterPath, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	v := url.Values{}
-	v.Set("limit", strconv.Itoa(limit))
-	v.Set("offset", strconv.Itoa(offset))
-	if totalCount {
-		v.Set("totalCount", "true")
+	if listOpts != nil {
+		values := req.URL.Query()
+		if listOpts.Limit != nil {
+			values.Set("limit", fmt.Sprint(*listOpts.Limit))
+		}
+		if listOpts.Offset != nil {
+			values.Set("offset", fmt.Sprint(*listOpts.Offset))
+		}
+		if listOpts.TotalCount != nil {
+			values.Set("totalCount", fmt.Sprint(*listOpts.TotalCount))
+		}
+		req.URL.RawQuery = values.Encode()
 	}
-	req.URL.RawQuery = v.Encode()
 
 	_, err = c.do(ctx, req, &adapters)
 	if err != nil {

--- a/kmip_mgmt_adapters.go
+++ b/kmip_mgmt_adapters.go
@@ -30,16 +30,6 @@ type KMIPAdapters struct {
 	Adapters []KMIPAdapter `json:"resources"`
 }
 
-type kmipProfileData interface {
-	Type() string
-}
-
-type KMIPProfileNative struct {
-	CrkID string `json:"crk_id"`
-}
-
-func (k KMIPProfileNative) Type() string { return KMIP_Profile_Native }
-
 const (
 	KMIP_Profile_Native = "native_1.0"
 )
@@ -123,12 +113,11 @@ func (c *Client) GetKMIPAdapter(ctx context.Context, id string) (*KMIPAdapter, e
 		return nil, err
 	}
 
-	return &adapters.Adapters[0], nil
+	return unwrapKMIPAdapterResp(&adapters), nil
 }
 
 func (c *Client) DeleteKMIPAdapter(ctx context.Context, id string) error {
 	req, err := c.newRequest("DELETE", fmt.Sprintf("%s/%s", KMIPAdapterPath, id), nil)
-
 	if err != nil {
 		return err
 	}

--- a/kmip_mgmt_adapters.go
+++ b/kmip_mgmt_adapters.go
@@ -16,7 +16,7 @@ const (
 type KMIPAdapter struct {
 	ID          string            `json:"id,omitempty"`
 	Profile     string            `json:"profile,omitempty"`
-	ProfileData KMIPProfileNative `json:"profile_data,omitempty"`
+	ProfileData map[string]string `json:"profile_data,omitempty"`
 	Name        string            `json:"name,omitempty"`
 	Description string            `json:"description"`
 	CreatedBy   string            `json:"created_by,omitempty"`
@@ -85,8 +85,8 @@ func WithNativeProfile(crkID string) CreateKMIPAdapterProfile {
 	return func(adapter *KMIPAdapter) {
 		adapter.Profile = KMIP_Profile_Native
 
-		adapter.ProfileData = KMIPProfileNative{
-			CrkID: crkID,
+		adapter.ProfileData = map[string]string{
+			"crk_id": crkID,
 		}
 	}
 }

--- a/kmip_mgmt_adapters.go
+++ b/kmip_mgmt_adapters.go
@@ -82,7 +82,6 @@ type ListKmipAdaptersOptions struct {
 	Limit      *uint32
 	Offset     *uint32
 	TotalCount *bool
-	// CrkID      *string
 }
 
 // GetKMIPAdapters method lists KMIP Adapters associated with a specific KP instance.
@@ -104,9 +103,6 @@ func (c *Client) GetKMIPAdapters(ctx context.Context, listOpts *ListKmipAdapters
 		if listOpts.TotalCount != nil {
 			values.Set("totalCount", fmt.Sprint(*listOpts.TotalCount))
 		}
-		// if listOpts.CrkID != nil {
-		// 	values.Set("crk_id", *listOpts.CrkID)
-		// }
 		req.URL.RawQuery = values.Encode()
 	}
 

--- a/kmip_mgmt_adapters.go
+++ b/kmip_mgmt_adapters.go
@@ -3,6 +3,8 @@ package kp
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -90,12 +92,17 @@ func WithNativeProfile(crkID string) CreateKMIPAdapterProfile {
 	}
 }
 
-func (c *Client) GetKMIPAdapters(ctx context.Context) (*KMIPAdapters, error) {
+func (c *Client) GetKMIPAdapters(ctx context.Context, limit, offset int) (*KMIPAdapters, error) {
 	adapters := KMIPAdapters{}
 	req, err := c.newRequest("GET", KMIPAdapterPath, nil)
 	if err != nil {
 		return nil, err
 	}
+
+	v := url.Values{}
+	v.Set("limit", strconv.Itoa(limit))
+	v.Set("offset", strconv.Itoa(offset))
+	req.URL.RawQuery = v.Encode()
 
 	_, err = c.do(ctx, req, &adapters)
 	if err != nil {

--- a/kmip_mgmt_certs.go
+++ b/kmip_mgmt_certs.go
@@ -3,6 +3,7 @@ package kp
 import (
 	"context"
 	"fmt"
+	"time"
 )
 
 const (
@@ -11,8 +12,11 @@ const (
 )
 
 type KMIPClientCertificate struct {
-	Name        string `json:"name,omitempty"`
-	Certificate string `json:"certificate,omitempty"`
+	ID          string     `json:"id,omitempty"`
+	Name        string     `json:"name,omitempty"`
+	Certificate string     `json:"certificate,omitempty"`
+	CreatedBy   string     `json:"created_by,omitempty"`
+	CreatedAt   *time.Time `json:"created_at,omitempty"`
 }
 
 type KMIPClientCertificates struct {

--- a/kmip_mgmt_certs.go
+++ b/kmip_mgmt_certs.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	KMIPClientCertSubPath = "certificates"
-	kmipClientCertType    = "application/vnd.ibm.kms.kmip_adapter+json"
+	kmipClientCertType    = "application/vnd.ibm.kms.kmip_client_certificate+json"
 )
 
 type KMIPClientCertificate struct {

--- a/kmip_mgmt_certs.go
+++ b/kmip_mgmt_certs.go
@@ -26,7 +26,8 @@ type KMIPClientCertificates struct {
 	Certificates []KMIPClientCertificate `json:"resources"`
 }
 
-// cert_payload is the string representation of the certificate to be associated with the KMIP Adapter.
+// cert_payload is the string representation of
+// the certificate to be associated with the KMIP Adapter in PEM format.
 // It should explicitly have the BEGIN CERTIFICATE and END CERTIFICATE tags.
 // Regex: ^\s*-----BEGIN CERTIFICATE-----[A-Za-z0-9+\/\=\r\n]+-----END CERTIFICATE-----\s*$
 func (c *Client) CreateKMIPClientCertificate(ctx context.Context, adapter_id, cert_payload string, opts ...CreateKMIPClientCertOption) (*KMIPClientCertificate, error) {
@@ -55,7 +56,7 @@ func WithKMIPClientCertName(name string) CreateKMIPClientCertOption {
 	}
 }
 
-func (c *Client) GetKMIPClientCertificates(ctx context.Context, adapter_id string, limit, offset int) (*KMIPClientCertificates, error) {
+func (c *Client) GetKMIPClientCertificates(ctx context.Context, adapter_id string, limit, offset int, totalCount bool) (*KMIPClientCertificates, error) {
 	certs := KMIPClientCertificates{}
 	req, err := c.newRequest("GET", fmt.Sprintf("%s/%s/%s", KMIPAdapterPath, adapter_id, KMIPClientCertSubPath), nil)
 	if err != nil {
@@ -65,6 +66,9 @@ func (c *Client) GetKMIPClientCertificates(ctx context.Context, adapter_id strin
 	v := url.Values{}
 	v.Set("limit", strconv.Itoa(limit))
 	v.Set("offset", strconv.Itoa(offset))
+	if totalCount {
+		v.Set("totalCount", "true")
+	}
 	req.URL.RawQuery = v.Encode()
 
 	_, err = c.do(ctx, req, &certs)

--- a/kmip_mgmt_certs.go
+++ b/kmip_mgmt_certs.go
@@ -26,6 +26,9 @@ type KMIPClientCertificates struct {
 	Certificates []KMIPClientCertificate `json:"resources"`
 }
 
+// cert_payload is the string representation of the certificate to be associated with the KMIP Adapter.
+// It should explicitly have the BEGIN CERTIFICATE and END CERTIFICATE tags.
+// Regex: ^\s*-----BEGIN CERTIFICATE-----[A-Za-z0-9+\/\=\r\n]+-----END CERTIFICATE-----\s*$
 func (c *Client) CreateKMIPClientCertificate(ctx context.Context, adapter_id, cert_payload string, opts ...CreateKMIPClientCertOption) (*KMIPClientCertificate, error) {
 	newCert := &KMIPClientCertificate{}
 	for _, opt := range opts {

--- a/kmip_mgmt_certs.go
+++ b/kmip_mgmt_certs.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	KMIPClientCertSubPath = "certificates"
+	kmipClientCertSubPath = "certificates"
 	kmipClientCertType    = "application/vnd.ibm.kms.kmip_client_certificate+json"
 )
 
@@ -24,16 +24,18 @@ type KMIPClientCertificates struct {
 	Certificates []KMIPClientCertificate `json:"resources"`
 }
 
+// CreateKMIPClientCertificate registers/creates a KMIP PEM format certificate
+// for use with a specific KMIP adapter.
 // cert_payload is the string representation of
 // the certificate to be associated with the KMIP Adapter in PEM format.
 // It should explicitly have the BEGIN CERTIFICATE and END CERTIFICATE tags.
 // Regex: ^\s*-----BEGIN CERTIFICATE-----[A-Za-z0-9+\/\=\r\n]+-----END CERTIFICATE-----\s*$
-func (c *Client) CreateKMIPClientCertificate(ctx context.Context, adapter_id, cert_payload string, opts ...CreateKMIPClientCertOption) (*KMIPClientCertificate, error) {
+func (c *Client) CreateKMIPClientCertificate(ctx context.Context, adapter_nameOrID, cert_payload string, opts ...CreateKMIPClientCertOption) (*KMIPClientCertificate, error) {
 	newCert := &KMIPClientCertificate{}
 	for _, opt := range opts {
 		opt(newCert)
 	}
-	req, err := c.newRequest("POST", fmt.Sprintf("%s/%s/%s", KMIPAdapterPath, adapter_id, KMIPClientCertSubPath), wrapKMIPClientCert(*newCert))
+	req, err := c.newRequest("POST", fmt.Sprintf("%s/%s/%s", kmipAdapterPath, adapter_nameOrID, kmipClientCertSubPath), wrapKMIPClientCert(*newCert))
 	if err != nil {
 		return nil, err
 	}
@@ -54,9 +56,10 @@ func WithKMIPClientCertName(name string) CreateKMIPClientCertOption {
 	}
 }
 
-func (c *Client) GetKMIPClientCertificates(ctx context.Context, adapter_id string, listOpts *ListOptions) (*KMIPClientCertificates, error) {
+// GetKMIPClientCertificates lists all certificates associated with a KMIP adapter
+func (c *Client) GetKMIPClientCertificates(ctx context.Context, adapter_nameOrID string, listOpts *ListOptions) (*KMIPClientCertificates, error) {
 	certs := KMIPClientCertificates{}
-	req, err := c.newRequest("GET", fmt.Sprintf("%s/%s/%s", KMIPAdapterPath, adapter_id, KMIPClientCertSubPath), nil)
+	req, err := c.newRequest("GET", fmt.Sprintf("%s/%s/%s", kmipAdapterPath, adapter_nameOrID, kmipClientCertSubPath), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -83,10 +86,11 @@ func (c *Client) GetKMIPClientCertificates(ctx context.Context, adapter_id strin
 	return &certs, nil
 }
 
-func (c *Client) GetKMIPClientCertificate(ctx context.Context, adapter_id, cert_id string) (*KMIPClientCertificate, error) {
+// GetKMIPClientCertificate gets a single certificate associated with a KMIP adapter
+func (c *Client) GetKMIPClientCertificate(ctx context.Context, adapter_nameOrID, cert_nameOrID string) (*KMIPClientCertificate, error) {
 	certs := &KMIPClientCertificates{}
 	req, err := c.newRequest("GET", fmt.Sprintf("%s/%s/%s/%s",
-		KMIPAdapterPath, adapter_id, KMIPClientCertSubPath, cert_id), nil)
+		kmipAdapterPath, adapter_nameOrID, kmipClientCertSubPath, cert_nameOrID), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -99,9 +103,10 @@ func (c *Client) GetKMIPClientCertificate(ctx context.Context, adapter_id, cert_
 	return unwrapKMIPClientCert(certs), nil
 }
 
-func (c *Client) DeleteKMIPClientCertificate(ctx context.Context, adapter_id, cert_id string) error {
+// DeleteKMIPClientCertificate deletes a single certificate
+func (c *Client) DeleteKMIPClientCertificate(ctx context.Context, adapter_nameOrID, cert_nameOrID string) error {
 	req, err := c.newRequest("DELETE", fmt.Sprintf("%s/%s/%s/%s",
-		KMIPAdapterPath, adapter_id, KMIPClientCertSubPath, cert_id), nil)
+		kmipAdapterPath, adapter_nameOrID, kmipClientCertSubPath, cert_nameOrID), nil)
 	if err != nil {
 		return err
 	}

--- a/kmip_mgmt_certs.go
+++ b/kmip_mgmt_certs.go
@@ -3,6 +3,8 @@ package kp
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -50,12 +52,17 @@ func WithKMIPClientCertName(name string) CreateKMIPClientCertOption {
 	}
 }
 
-func (c *Client) GetKMIPClientCertificates(ctx context.Context, adapter_id string) (*KMIPClientCertificates, error) {
+func (c *Client) GetKMIPClientCertificates(ctx context.Context, adapter_id string, limit, offset int) (*KMIPClientCertificates, error) {
 	certs := KMIPClientCertificates{}
 	req, err := c.newRequest("GET", fmt.Sprintf("%s/%s/%s", KMIPAdapterPath, adapter_id, KMIPClientCertSubPath), nil)
 	if err != nil {
 		return nil, err
 	}
+
+	v := url.Values{}
+	v.Set("limit", strconv.Itoa(limit))
+	v.Set("offset", strconv.Itoa(offset))
+	req.URL.RawQuery = v.Encode()
 
 	_, err = c.do(ctx, req, &certs)
 	if err != nil {

--- a/kmip_mgmt_certs.go
+++ b/kmip_mgmt_certs.go
@@ -22,7 +22,7 @@ type KMIPClientCertificate struct {
 }
 
 type KMIPClientCertificates struct {
-	Metadata     KeysMetadata            `json:"metadata"`
+	Metadata     CollectionMetadata      `json:"metadata"`
 	Certificates []KMIPClientCertificate `json:"resources"`
 }
 
@@ -112,9 +112,9 @@ func (c *Client) DeleteKMIPClientCertificate(ctx context.Context, adapter_id, ce
 
 func wrapKMIPClientCert(cert KMIPClientCertificate) KMIPClientCertificates {
 	return KMIPClientCertificates{
-		Metadata: KeysMetadata{
-			CollectionType: kmipClientCertType,
-			NumberOfKeys:   1,
+		Metadata: CollectionMetadata{
+			CollectionType:  kmipClientCertType,
+			CollectionTotal: 1,
 		},
 		Certificates: []KMIPClientCertificate{cert},
 	}

--- a/kmip_mgmt_certs.go
+++ b/kmip_mgmt_certs.go
@@ -1,0 +1,107 @@
+package kp
+
+import (
+	"context"
+	"fmt"
+)
+
+const (
+	KMIPClientCertSubPath = "certificates"
+	kmipClientCertType    = "application/vnd.ibm.kms.kmip_adapter+json"
+)
+
+type KMIPClientCertificate struct {
+	Name        string `json:"name,omitempty"`
+	Certificate string `json:"certificate,omitempty"`
+}
+
+type KMIPClientCertificates struct {
+	Metadata     KeysMetadata            `json:"metadata"`
+	Certificates []KMIPClientCertificate `json:"resources"`
+}
+
+func (c *Client) CreateKMIPClientCertificate(ctx context.Context, adapter_id, cert_payload string, opts ...CreateKMIPClientCertOption) (*KMIPClientCertificate, error) {
+	newCert := &KMIPClientCertificate{}
+	for _, opt := range opts {
+		opt(newCert)
+	}
+	req, err := c.newRequest("POST", fmt.Sprintf("%s/%s/%s", KMIPAdapterPath, adapter_id, KMIPClientCertSubPath), wrapKMIPClientCert(*newCert))
+	if err != nil {
+		return nil, err
+	}
+	certResp := &KMIPClientCertificates{}
+	_, err = c.do(ctx, req, certResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return unwrapKMIPClientCert(certResp), nil
+}
+
+type CreateKMIPClientCertOption func(*KMIPClientCertificate)
+
+func WithKMIPClientCertName(name string) CreateKMIPClientCertOption {
+	return func(cert *KMIPClientCertificate) {
+		cert.Name = name
+	}
+}
+
+func (c *Client) GetKMIPClientCertificates(ctx context.Context, adapter_id string) (*KMIPClientCertificates, error) {
+	certs := KMIPClientCertificates{}
+	req, err := c.newRequest("GET", fmt.Sprintf("%s/%s/%s", KMIPAdapterPath, adapter_id, KMIPClientCertSubPath), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = c.do(ctx, req, &certs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &certs, nil
+}
+
+func (c *Client) GetKMIPClientCertificate(ctx context.Context, adapter_id, cert_id string) (*KMIPClientCertificate, error) {
+	certs := &KMIPClientCertificates{}
+	req, err := c.newRequest("GET", fmt.Sprintf("%s/%s/%s/%s",
+		KMIPAdapterPath, adapter_id, KMIPClientCertSubPath, cert_id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = c.do(ctx, req, certs)
+	if err != nil {
+		return nil, err
+	}
+
+	return unwrapKMIPClientCert(certs), nil
+}
+
+func (c *Client) DeleteKMIPClientCertificate(ctx context.Context, adapter_id, cert_id string) error {
+	req, err := c.newRequest("DELETE", fmt.Sprintf("%s/%s/%s/%s",
+		KMIPAdapterPath, adapter_id, KMIPClientCertSubPath, cert_id), nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.do(ctx, req, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func wrapKMIPClientCert(cert KMIPClientCertificate) KMIPClientCertificates {
+	return KMIPClientCertificates{
+		Metadata: KeysMetadata{
+			CollectionType: kmipClientCertType,
+			NumberOfKeys:   1,
+		},
+		Certificates: []KMIPClientCertificate{cert},
+	}
+}
+
+func unwrapKMIPClientCert(certs *KMIPClientCertificates) *KMIPClientCertificate {
+	return &certs.Certificates[0]
+}

--- a/kmip_mgmt_certs.go
+++ b/kmip_mgmt_certs.go
@@ -31,7 +31,9 @@ type KMIPClientCertificates struct {
 // It should explicitly have the BEGIN CERTIFICATE and END CERTIFICATE tags.
 // Regex: ^\s*-----BEGIN CERTIFICATE-----[A-Za-z0-9+\/\=\r\n]+-----END CERTIFICATE-----\s*$
 func (c *Client) CreateKMIPClientCertificate(ctx context.Context, adapter_nameOrID, cert_payload string, opts ...CreateKMIPClientCertOption) (*KMIPClientCertificate, error) {
-	newCert := &KMIPClientCertificate{}
+	newCert := &KMIPClientCertificate{
+		Certificate: cert_payload,
+	}
 	for _, opt := range opts {
 		opt(newCert)
 	}

--- a/kmip_mgmt_certs.go
+++ b/kmip_mgmt_certs.go
@@ -3,8 +3,6 @@ package kp
 import (
 	"context"
 	"fmt"
-	"net/url"
-	"strconv"
 	"time"
 )
 
@@ -56,20 +54,26 @@ func WithKMIPClientCertName(name string) CreateKMIPClientCertOption {
 	}
 }
 
-func (c *Client) GetKMIPClientCertificates(ctx context.Context, adapter_id string, limit, offset int, totalCount bool) (*KMIPClientCertificates, error) {
+func (c *Client) GetKMIPClientCertificates(ctx context.Context, adapter_id string, listOpts *ListOptions) (*KMIPClientCertificates, error) {
 	certs := KMIPClientCertificates{}
 	req, err := c.newRequest("GET", fmt.Sprintf("%s/%s/%s", KMIPAdapterPath, adapter_id, KMIPClientCertSubPath), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	v := url.Values{}
-	v.Set("limit", strconv.Itoa(limit))
-	v.Set("offset", strconv.Itoa(offset))
-	if totalCount {
-		v.Set("totalCount", "true")
+	if listOpts != nil {
+		values := req.URL.Query()
+		if listOpts.Limit != nil {
+			values.Set("limit", fmt.Sprint(*listOpts.Limit))
+		}
+		if listOpts.Offset != nil {
+			values.Set("offset", fmt.Sprint(*listOpts.Offset))
+		}
+		if listOpts.TotalCount != nil {
+			values.Set("totalCount", fmt.Sprint(*listOpts.TotalCount))
+		}
+		req.URL.RawQuery = values.Encode()
 	}
-	req.URL.RawQuery = v.Encode()
 
 	_, err = c.do(ctx, req, &certs)
 	if err != nil {

--- a/kmip_mgmt_objects.go
+++ b/kmip_mgmt_objects.go
@@ -3,6 +3,7 @@ package kp
 import (
 	"context"
 	"fmt"
+	"time"
 )
 
 const (
@@ -13,16 +14,17 @@ const (
 type KMIPObject struct {
 	ID                string
 	KMIPObjectType    int
+	ObjectState       int
 	KMIPAdapterID     string
 	CreatedByCertID   string
 	CreatedBy         string
-	CreatedAt         string
+	CreatedAt         *time.Time
 	UpdatedByCertID   string
 	UpdatedBy         string
-	UpdatedAt         string
+	UpdatedAt         *time.Time
 	DestroyedByCertID string
 	DestroyedBy       string
-	DestroyedAt       string
+	DestroyedAt       *time.Time
 }
 
 type KMIPObjects struct {
@@ -30,7 +32,7 @@ type KMIPObjects struct {
 	Objects  []KMIPObject `json:"resources"`
 }
 
-func (c *Client) GetKMIPObject(ctx context.Context, adapter_id string) (*KMIPObject, error) {
+func (c *Client) GetKMIPObjects(ctx context.Context, adapter_id string) (*KMIPObject, error) {
 	objects := KMIPObject{}
 	req, err := c.newRequest("GET", fmt.Sprintf("%s/%s/%s", KMIPAdapterPath, adapter_id, KMIPObjectSubPath), nil)
 	if err != nil {
@@ -89,5 +91,3 @@ func wrapKMIPObject(object KMIPObject) KMIPObjects {
 func unwrapKMIPObject(objects *KMIPObjects) *KMIPObject {
 	return &objects.Objects[0]
 }
-
-//TODO: get list delete

--- a/kmip_mgmt_objects.go
+++ b/kmip_mgmt_objects.go
@@ -1,0 +1,93 @@
+package kp
+
+import (
+	"context"
+	"fmt"
+)
+
+const (
+	KMIPObjectSubPath = "kmip_objects"
+	kmipObjectType    = "application/vnd.ibm.kms.kmip_object+json"
+)
+
+type KMIPObject struct {
+	ID                string
+	KMIPObjectType    int
+	KMIPAdapterID     string
+	CreatedByCertID   string
+	CreatedBy         string
+	CreatedAt         string
+	UpdatedByCertID   string
+	UpdatedBy         string
+	UpdatedAt         string
+	DestroyedByCertID string
+	DestroyedBy       string
+	DestroyedAt       string
+}
+
+type KMIPObjects struct {
+	Metadata KeysMetadata `json:"metadata"`
+	Objects  []KMIPObject `json:"resources"`
+}
+
+func (c *Client) GetKMIPObject(ctx context.Context, adapter_id string) (*KMIPObject, error) {
+	objects := KMIPObject{}
+	req, err := c.newRequest("GET", fmt.Sprintf("%s/%s/%s", KMIPAdapterPath, adapter_id, KMIPObjectSubPath), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = c.do(ctx, req, &objects)
+	if err != nil {
+		return nil, err
+	}
+
+	return &objects, nil
+}
+
+func (c *Client) GetKMIPObject(ctx context.Context, adapter_id, object_id string) (*KMIPObject, error) {
+	objects := &KMIPObjects{}
+	req, err := c.newRequest("GET", fmt.Sprintf("%s/%s/%s/%s",
+		KMIPAdapterPath, adapter_id, KMIPObjectSubPath, object_id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = c.do(ctx, req, objects)
+	if err != nil {
+		return nil, err
+	}
+
+	return unwrapKMIPObject(objects), nil
+}
+
+func (c *Client) DeleteKMIPObject(ctx context.Context, adapter_id, object_id string) error {
+	req, err := c.newRequest("DELETE", fmt.Sprintf("%s/%s/%s/%s",
+		KMIPAdapterPath, adapter_id, KMIPObjectSubPath, object_id), nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.do(ctx, req, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func wrapKMIPObject(object KMIPObject) KMIPObjects {
+	return KMIPObjects{
+		Metadata: KeysMetadata{
+			CollectionType: kmipObjectType,
+			NumberOfKeys:   1,
+		},
+		Objects: []KMIPObject{object},
+	}
+}
+
+func unwrapKMIPObject(objects *KMIPObjects) *KMIPObject {
+	return &objects.Objects[0]
+}
+
+//TODO: get list delete

--- a/kmip_mgmt_objects.go
+++ b/kmip_mgmt_objects.go
@@ -33,7 +33,7 @@ type KMIPObjects struct {
 	Objects  []KMIPObject `json:"resources"`
 }
 
-func (c *Client) GetKMIPObjects(ctx context.Context, adapter_id string, limit, offset int) (*KMIPObjects, error) {
+func (c *Client) GetKMIPObjects(ctx context.Context, adapter_id string, limit, offset int, totalCount bool) (*KMIPObjects, error) {
 	objects := KMIPObjects{}
 	req, err := c.newRequest("GET", fmt.Sprintf("%s/%s/%s", KMIPAdapterPath, adapter_id, KMIPObjectSubPath), nil)
 	if err != nil {
@@ -43,6 +43,9 @@ func (c *Client) GetKMIPObjects(ctx context.Context, adapter_id string, limit, o
 	v := url.Values{}
 	v.Set("limit", strconv.Itoa(limit))
 	v.Set("offset", strconv.Itoa(offset))
+	if totalCount {
+		v.Set("totalCount", "true")
+	}
 	req.URL.RawQuery = v.Encode()
 
 	_, err = c.do(ctx, req, &objects)

--- a/kmip_mgmt_objects.go
+++ b/kmip_mgmt_objects.go
@@ -29,8 +29,8 @@ type KMIPObject struct {
 }
 
 type KMIPObjects struct {
-	Metadata KeysMetadata `json:"metadata"`
-	Objects  []KMIPObject `json:"resources"`
+	Metadata CollectionMetadata `json:"metadata"`
+	Objects  []KMIPObject       `json:"resources"`
 }
 
 func (c *Client) GetKMIPObjects(ctx context.Context, adapter_id string, limit, offset int, totalCount bool) (*KMIPObjects, error) {
@@ -89,9 +89,9 @@ func (c *Client) DeleteKMIPObject(ctx context.Context, adapter_id, object_id str
 
 func wrapKMIPObject(object KMIPObject) KMIPObjects {
 	return KMIPObjects{
-		Metadata: KeysMetadata{
-			CollectionType: kmipObjectType,
-			NumberOfKeys:   1,
+		Metadata: CollectionMetadata{
+			CollectionType:  kmipObjectType,
+			CollectionTotal: 1,
 		},
 		Objects: []KMIPObject{object},
 	}

--- a/kmip_mgmt_objects.go
+++ b/kmip_mgmt_objects.go
@@ -14,19 +14,18 @@ const (
 )
 
 type KMIPObject struct {
-	ID                string
-	KMIPObjectType    int
-	ObjectState       int
-	KMIPAdapterID     string
-	CreatedByCertID   string
-	CreatedBy         string
-	CreatedAt         *time.Time
-	UpdatedByCertID   string
-	UpdatedBy         string
-	UpdatedAt         *time.Time
-	DestroyedByCertID string
-	DestroyedBy       string
-	DestroyedAt       *time.Time
+	ID                string     `json:"id,omitempty"`
+	KMIPObjectType    int        `json:"kmip_object_type,omitempty"`
+	ObjectState       int        `json:"state,omitempty"`
+	CreatedByCertID   string     `json:"created_by_kmip_client_cert_id,omitempty"`
+	CreatedBy         string     `json:"created_by,omitempty"`
+	CreatedAt         *time.Time `json:"created_at,omitempty"`
+	UpdatedByCertID   string     `json:"updated_by_kmip_client_cert_id,omitempty"`
+	UpdatedBy         string     `json:"updated_by,omitempty"`
+	UpdatedAt         *time.Time `json:"updated_at,omitempty"`
+	DestroyedByCertID string     `json:"destroyed_by_kmip_client_cert_id,omitempty"`
+	DestroyedBy       string     `json:"destroyed_by,omitempty"`
+	DestroyedAt       *time.Time `json:"destroyed_at,omitempty"`
 }
 
 type KMIPObjects struct {

--- a/kmip_mgmt_objects.go
+++ b/kmip_mgmt_objects.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	KMIPObjectSubPath = "kmip_objects"
+	kmipObjectSubPath = "kmip_objects"
 	kmipObjectType    = "application/vnd.ibm.kms.kmip_object+json"
 )
 
@@ -42,7 +42,7 @@ type ListKmipObjectsOptions struct {
 
 func (c *Client) GetKMIPObjects(ctx context.Context, adapter_id string, listOpts *ListKmipObjectsOptions) (*KMIPObjects, error) {
 	objects := KMIPObjects{}
-	req, err := c.newRequest("GET", fmt.Sprintf("%s/%s/%s", KMIPAdapterPath, adapter_id, KMIPObjectSubPath), nil)
+	req, err := c.newRequest("GET", fmt.Sprintf("%s/%s/%s", kmipAdapterPath, adapter_id, kmipObjectSubPath), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (c *Client) GetKMIPObjects(ctx context.Context, adapter_id string, listOpts
 func (c *Client) GetKMIPObject(ctx context.Context, adapter_id, object_id string) (*KMIPObject, error) {
 	objects := &KMIPObjects{}
 	req, err := c.newRequest("GET", fmt.Sprintf("%s/%s/%s/%s",
-		KMIPAdapterPath, adapter_id, KMIPObjectSubPath, object_id), nil)
+		kmipAdapterPath, adapter_id, kmipObjectSubPath, object_id), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func (c *Client) GetKMIPObject(ctx context.Context, adapter_id, object_id string
 
 func (c *Client) DeleteKMIPObject(ctx context.Context, adapter_id, object_id string) error {
 	req, err := c.newRequest("DELETE", fmt.Sprintf("%s/%s/%s/%s",
-		KMIPAdapterPath, adapter_id, KMIPObjectSubPath, object_id), nil)
+		kmipAdapterPath, adapter_id, kmipObjectSubPath, object_id), nil)
 	if err != nil {
 		return err
 	}

--- a/kmip_mgmt_objects.go
+++ b/kmip_mgmt_objects.go
@@ -3,6 +3,8 @@ package kp
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -32,12 +34,17 @@ type KMIPObjects struct {
 	Objects  []KMIPObject `json:"resources"`
 }
 
-func (c *Client) GetKMIPObjects(ctx context.Context, adapter_id string) (*KMIPObject, error) {
-	objects := KMIPObject{}
+func (c *Client) GetKMIPObjects(ctx context.Context, adapter_id string, limit, offset int) (*KMIPObjects, error) {
+	objects := KMIPObjects{}
 	req, err := c.newRequest("GET", fmt.Sprintf("%s/%s/%s", KMIPAdapterPath, adapter_id, KMIPObjectSubPath), nil)
 	if err != nil {
 		return nil, err
 	}
+
+	v := url.Values{}
+	v.Set("limit", strconv.Itoa(limit))
+	v.Set("offset", strconv.Itoa(offset))
+	req.URL.RawQuery = v.Encode()
 
 	_, err = c.do(ctx, req, &objects)
 	if err != nil {

--- a/kmip_mgmt_objects.go
+++ b/kmip_mgmt_objects.go
@@ -37,7 +37,7 @@ type ListKmipObjectsOptions struct {
 	Limit             *uint32
 	Offset            *uint32
 	TotalCount        *bool
-	ObjectStateFilter *[]int
+	ObjectStateFilter *[]int32
 }
 
 func (c *Client) GetKMIPObjects(ctx context.Context, adapter_id string, listOpts *ListKmipObjectsOptions) (*KMIPObjects, error) {
@@ -61,7 +61,7 @@ func (c *Client) GetKMIPObjects(ctx context.Context, adapter_id string, listOpts
 		if listOpts.ObjectStateFilter != nil {
 			var stateStrs []string
 			for _, i := range *listOpts.ObjectStateFilter {
-				stateStrs = append(stateStrs, strconv.Itoa(i))
+				stateStrs = append(stateStrs, strconv.FormatInt(int64(i), 10))
 			}
 			values.Set("state", strings.Join(stateStrs, ","))
 		}

--- a/kp.go
+++ b/kp.go
@@ -516,8 +516,16 @@ func noredact(s string, redactStrings []string) string {
 	return s
 }
 
+// Collection Metadata is generic and can be shared between multiple resource types
 type CollectionMetadata struct {
 	CollectionType  string `json:"collectionType"`
 	CollectionTotal int    `json:"collectionTotal"`
 	TotalCount      int    `json:"totalCount,omitempty"`
+}
+
+// ListsOptions struct to add the query parameters for list functions. Extensible.
+type ListOptions struct {
+	Limit      *uint32
+	Offset     *uint32
+	TotalCount *bool
 }

--- a/kp.go
+++ b/kp.go
@@ -515,3 +515,9 @@ func redact(s string, redactStrings []string) string {
 func noredact(s string, redactStrings []string) string {
 	return s
 }
+
+type CollectionMetadata struct {
+	CollectionType  string `json:"collectionType"`
+	CollectionTotal int    `json:"collectionTotal"`
+	TotalCount      int    `json:"totalCount,omitempty"`
+}

--- a/kp.go
+++ b/kp.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -276,7 +275,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, res interface{}) (*h
 	}
 	defer response.Body.Close()
 
-	resBody, err := ioutil.ReadAll(response.Body)
+	resBody, err := io.ReadAll(response.Body)
 	redact := []string{c.Config.APIKey, req.Header.Get("authorization")}
 	c.Dump(req, response, []byte{}, resBody, c.Logger, redact)
 	if err != nil {

--- a/kp_test.go
+++ b/kp_test.go
@@ -5357,6 +5357,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 			"KMIP Adapter Create",
 			func(t *testing.T, api *API, ctx context.Context) error {
 				defer gock.Off()
+				MockAuth()
 				gock.New(baseURL).
 					Post(adapterPath).
 					Reply(http.StatusCreated).
@@ -5377,6 +5378,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 			"KMIP Adapter List",
 			func(t *testing.T, api *API, ctx context.Context) error {
 				defer gock.Off()
+				MockAuth()
 				gock.New(baseURL).
 					Get(adapterPath).
 					Reply(http.StatusOK).
@@ -5391,6 +5393,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 			"KMIP Adapter Get",
 			func(t *testing.T, api *API, ctx context.Context) error {
 				defer gock.Off()
+				MockAuth()
 				gock.New(baseURL).
 					Get(adapterPathID).
 					Reply(http.StatusOK).
@@ -5405,6 +5408,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 			"KMIP Adapter Delete",
 			func(t *testing.T, api *API, ctx context.Context) error {
 				defer gock.Off()
+				MockAuth()
 				gock.New(baseURL).
 					Delete(adapterPathID).
 					Reply(http.StatusOK)
@@ -5417,6 +5421,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 			"KMIP Client Certificate Create",
 			func(t *testing.T, api *API, ctx context.Context) error {
 				defer gock.Off()
+				MockAuth()
 				gock.New(baseURL).
 					Post(certPath).
 					Reply(http.StatusCreated).
@@ -5436,6 +5441,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 			"KMIP Client Certificate List",
 			func(t *testing.T, api *API, ctx context.Context) error {
 				defer gock.Off()
+				MockAuth()
 				gock.New(baseURL).
 					Get(certPath).
 					Reply(http.StatusOK).
@@ -5450,6 +5456,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 			"KMIP Client Certificate Get",
 			func(t *testing.T, api *API, ctx context.Context) error {
 				defer gock.Off()
+				MockAuth()
 				gock.New(baseURL).
 					Get(certPath + UUID).
 					Reply(http.StatusOK).
@@ -5465,6 +5472,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 			"KMIP Client Certificate Delete",
 			func(t *testing.T, api *API, ctx context.Context) error {
 				defer gock.Off()
+				MockAuth()
 				gock.New(baseURL).
 					Delete(certPath + UUID).
 					Reply(http.StatusOK)
@@ -5478,6 +5486,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 			"KMIP Object List",
 			func(t *testing.T, api *API, ctx context.Context) error {
 				defer gock.Off()
+				MockAuth()
 				gock.New(baseURL).
 					Get(objectPath).
 					Reply(http.StatusOK).
@@ -5492,6 +5501,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 			"KMIP Object Get",
 			func(t *testing.T, api *API, ctx context.Context) error {
 				defer gock.Off()
+				MockAuth()
 				gock.New(baseURL).
 					Get(objectPath + UUID).
 					Reply(http.StatusOK).
@@ -5506,6 +5516,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 			"KMIP Object Delete",
 			func(t *testing.T, api *API, ctx context.Context) error {
 				defer gock.Off()
+				MockAuth()
 				gock.New(baseURL).
 					Delete(objectPath + UUID).
 					Reply(http.StatusOK)

--- a/kp_test.go
+++ b/kp_test.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 	"time"
 
-	kp "github.com/IBM/keyprotect-go-client"
 	"github.com/IBM/keyprotect-go-client/iam"
 	"github.com/google/uuid"
 
@@ -5320,10 +5319,10 @@ func TestKMIPMgmtAPI(t *testing.T) {
 		},
 	}
 
-	adapterURL := "/api/v2/" + kp.KMIPAdapterPath + "/"
+	adapterURL := "/api/v2/" + KMIPAdapterPath + "/"
 	adapterURLRoot := adapterURL + UUID + "/"
-	certURL := adapterURLRoot + kp.KMIPClientCertSubPath + "/"
-	objectURL := adapterURLRoot + kp.KMIPObjectSubPath + "/"
+	certURL := adapterURLRoot + KMIPClientCertSubPath + "/"
+	objectURL := adapterURLRoot + KMIPObjectSubPath + "/"
 	cases := TestCases{
 		{
 			"KMIP Adapter Create",

--- a/kp_test.go
+++ b/kp_test.go
@@ -5257,94 +5257,137 @@ func TestListKeyFilter(t *testing.T) {
 func TestKMIPMgmtAPI(t *testing.T) {
 	defer gock.Off()
 	UUID := "feddecaf-0000-0000-0000-1234567890ab"
-	exampleIBMID := "IBMid-0000000000"
-	kmipAdapterProfile := "native_1.0"
 	crkUUID := "beddecaf-0000-0000-0000-1234567890ab"
-	timestamp := time.Now()
-	newAdapter := KMIPAdapter{
-		ID:      UUID,
-		Name:    "kmip-adapter-123",
-		Profile: kmipAdapterProfile,
-		ProfileData: map[string]string{
-			"crk_id": crkUUID,
+	singleAdapter := []byte(`{
+		"metadata": {
+		  "collectionType": "application/vnd.ibm.kms.kmip-adapter+json",
+		  "collectionTotal": 1,
 		},
-		Description: "our 123rd kmip adapter",
-		CreatedAt:   &timestamp,
-		CreatedBy:   exampleIBMID,
-	}
-	newCertificate := KMIPClientCertificate{
-		ID:        UUID,
-		Name:      "kmip-client-certificate",
-		CreatedAt: &timestamp,
-		CreatedBy: exampleIBMID,
-	}
-	newKmipObject := KMIPObject{
-		ID:              UUID,
-		KMIPObjectType:  2,
-		ObjectState:     1,
-		CreatedByCertID: newCertificate.ID,
-		CreatedBy:       exampleIBMID,
-		CreatedAt:       &timestamp,
-	}
-
-	singleAdapter := &KMIPAdapters{
-		Metadata: KeysMetadata{
-			CollectionType: kmipAdapterType,
-			NumberOfKeys:   1,
+		"resources": [
+		  {
+			"id": "feddecaf-0000-0000-0000-1234567890ab",
+			"profile": "native_1.0",
+			"profile_data": {
+			  "crk_id": "beddecaf-0000-0000-0000-1234567890ab"
+			},
+			"name": "kmip-adapter-123",
+			"description": "our 123rd kmip adapter",
+			"created_at": "2023-01-23T04:56:07.000Z",
+			"created_by": "IBMid-0000000000",
+			"updated_at": "2023-01-23T04:56:07.000Z",
+			"updated_by": "IBMid-0000000000"
+		  }
+		]
+	  }`)
+	testAdapters := []byte(`{
+		"metadata": {
+		  "collectionType": "application/vnd.ibm.kms.kmip-adapter+json",
+		  "collectionTotal": 1,
+		  "totalCount": 3
 		},
-		Adapters: []KMIPAdapter{
-			newAdapter,
+		"resources": [
+		  {
+			"id": "feddecaf-0000-0000-0000-1234567890ab",
+			"profile": "native_1.0",
+			"profile_data": {
+			  "crk_id": "beddecaf-0000-0000-0000-1234567890ab"
+			},
+			"name": "kmip-adapter-123",
+			"description": "our 123rd kmip adapter",
+			"created_at": "2023-01-23T04:56:07.000Z",
+			"created_by": "IBMid-0000000000",
+			"updated_at": "2023-01-23T04:56:07.000Z",
+			"updated_by": "IBMid-0000000000"
+		  }
+		]
+	  }`)
+	singleCert := []byte(`{
+		"metadata": {
+		  "collectionType": "application/vnd.ibm.kms.kmip_client_certificate+json",
+		  "collectionTotal": 1
 		},
-	}
-	testAdapters := &KMIPAdapters{
-		Metadata: KeysMetadata{
-			CollectionType: kmipAdapterType,
-			NumberOfKeys:   2,
+		"resources": [
+		  {
+			"id": "feddecaf-0000-0000-0000-1234567890ab",
+			"name": "kmip-client-certificate",
+			"created_at": "2000-01-23T04:56:07.000Z",
+			"created_by": "IBMid-0000000000"
+		  }
+		]
+	  }`)
+	testCerts := []byte(`{
+		"metadata": {
+		  "collectionType": "application/vnd.ibm.kms.kmip_client_certificate+json",
+		  "collectionTotal": 2,
+		  "totalCount": 4
 		},
-		Adapters: []KMIPAdapter{
-			newAdapter,
-			newAdapter,
+		"resources": [
+		  {
+			"id": "feddecaf-0000-0000-0000-1234567890ab",
+			"name": "kmip-client-certificate",
+			"created_at": "2000-01-23T04:56:07.000Z",
+			"created_by": "IBMid-0000000000"
+		  },
+		  {
+			"id": "beddecaf-0000-0000-0000-1234567890ab",
+			"name": "kmip-client-certificate2",
+			"created_at": "2001-01-23T04:56:07.000Z",
+			"created_by": "IBMid-0000000001"
+		  }
+		]
+	  }`)
+	singleKmipObject := []byte(`{
+		"metadata": {
+		  "collectionType": "application/vnd.ibm.kms.kmip_object+json",
+		  "collectionTotal": 1
 		},
-	}
-	singleCert := &KMIPClientCertificates{
-		Metadata: KeysMetadata{
-			CollectionType: kmipClientCertType,
-			NumberOfKeys:   1,
+		"resources": [
+		  {
+			"id": "feddecaf-0000-0000-0000-1234567890ab",
+			"kmip_object_type": "symmetric_key",
+			"state": 3,
+			"created_at": "2000-01-23T04:56:07.000Z",
+			"created_by_kmip_client_cert_id": "reddecaf-0000-0000-0000-1234567890ab",
+			"created_by": "IBMid-0000000001",
+			"updated_at": "2000-02-23T08:19:00.000Z",
+			"updated_by_kmip_client_cert_id": "reddecaf-0000-0000-0000-1234567890ab",
+			"updated_by": "IBMid-0000000001"
+		  }
+		]
+	  }`)
+	testKmipObjects := []byte(`{
+		"metadata": {
+		  "collectionType": "application/vnd.ibm.kms.kmip_object+json",
+		  "collectionTotal": 2,
+		  "totalCount": 4
 		},
-		Certificates: []KMIPClientCertificate{
-			newCertificate,
-		},
-	}
-	testCerts := &KMIPClientCertificates{
-		Metadata: KeysMetadata{
-			CollectionType: kmipClientCertType,
-			NumberOfKeys:   2,
-		},
-		Certificates: []KMIPClientCertificate{
-			newCertificate,
-			newCertificate,
-		},
-	}
-
-	singleKmipObject := &KMIPObjects{
-		Metadata: KeysMetadata{
-			CollectionType: kmipObjectType,
-			NumberOfKeys:   1,
-		},
-		Objects: []KMIPObject{
-			newKmipObject,
-		},
-	}
-	testKmipObjects := &KMIPObjects{
-		Metadata: KeysMetadata{
-			CollectionType: kmipObjectType,
-			NumberOfKeys:   2,
-		},
-		Objects: []KMIPObject{
-			newKmipObject,
-			newKmipObject,
-		},
-	}
+		"resources": [
+		  {
+			"id": "feddecaf-0000-0000-0000-1234567890ab",
+			"kmip_object_type": "symmetric_key",
+			"state": 3,
+			"created_at": "2000-01-23T04:56:07.000Z",
+			"created_by_kmip_client_cert_id": "reddecaf-0000-0000-0000-1234567890ab",
+			"created_by": "IBMid-0000000001",
+			"updated_at": "2000-02-23T08:19:00.000Z",
+			"updated_by_kmip_client_cert_id": "reddecaf-0000-0000-0000-1234567890ab",
+			"updated_by": "IBMid-0000000001"
+		  },
+		  {
+			"id": "beddecaf-0000-0000-0000-1234567890ab",
+			"kmip_object_type": "symmetric_key",
+			"state": 5,
+			"created_at": "2000-01-23T04:56:07.000Z",
+			"created_by_kmip_client_cert_id": "reddecaf-0000-0000-0000-1234567890ab",
+			"created_by": "IBMid-0000000001",
+			"updated_at": "2000-03-25T04:56:07.000Z",
+			"updated_by_kmip_client_cert_id": "reddecaf-0000-0000-0000-1234567890ab",
+			"updated_by": "IBMid-0000000001",
+			"destroyed_at": "2000-03-28T04:56:07.000Z",
+			"destroyed_by": "IBMid-0000000001"
+		  }
+		]
+	  }`)
 
 	baseURL := "http://example.com"
 	adapterPath := "/api/v2/" + KMIPAdapterPath
@@ -5384,7 +5427,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 					JSON(testAdapters)
 				adapters, err := api.GetKMIPAdapters(ctx, 100, 0, true)
 				assert.NoError(t, err)
-				assert.Equal(t, adapters.Metadata.NumberOfKeys, testAdapters.Metadata.NumberOfKeys)
+				assert.Equal(t, adapters.Metadata.CollectionTotal, testAdapters.Metadata.NumberOfKeys)
 				return nil
 			},
 		},
@@ -5447,7 +5490,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 					JSON(testCerts)
 				certs, err := api.GetKMIPClientCertificates(ctx, UUID, 100, 0, true)
 				assert.NoError(t, err)
-				assert.Equal(t, certs.Metadata.NumberOfKeys, testCerts.Metadata.NumberOfKeys)
+				assert.Equal(t, certs.Metadata.CollectionTotal, testCerts.Metadata.NumberOfKeys)
 				return nil
 			},
 		},
@@ -5492,7 +5535,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 					JSON(testKmipObjects)
 				KmipObjects, err := api.GetKMIPObjects(ctx, UUID, 100, 0, false)
 				assert.NoError(t, err)
-				assert.Equal(t, KmipObjects.Metadata.NumberOfKeys, testKmipObjects.Metadata.NumberOfKeys)
+				assert.Equal(t, KmipObjects.Metadata.CollectionTotal, testKmipObjects.Metadata.NumberOfKeys)
 				return nil
 			},
 		},

--- a/kp_test.go
+++ b/kp_test.go
@@ -5264,7 +5264,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 	singleAdapter := []byte(`{
 		"metadata": {
 		  "collectionType": "application/vnd.ibm.kms.kmip-adapter+json",
-		  "collectionTotal": 1,
+		  "collectionTotal": 1
 		},
 		"resources": [
 		  {

--- a/kp_test.go
+++ b/kp_test.go
@@ -5282,7 +5282,6 @@ func TestKMIPMgmtAPI(t *testing.T) {
 		ID:              UUID,
 		KMIPObjectType:  2,
 		ObjectState:     1,
-		KMIPAdapterID:   newAdapter.ID,
 		CreatedByCertID: newCertificate.ID,
 		CreatedBy:       exampleIBMID,
 		CreatedAt:       &timestamp,
@@ -5383,7 +5382,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 					Get(adapterPath).
 					Reply(http.StatusOK).
 					JSON(testAdapters)
-				adapters, err := api.GetKMIPAdapters(ctx, 100, 0)
+				adapters, err := api.GetKMIPAdapters(ctx, 100, 0, true)
 				assert.NoError(t, err)
 				assert.Equal(t, adapters.Metadata.NumberOfKeys, testAdapters.Metadata.NumberOfKeys)
 				return nil
@@ -5446,7 +5445,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 					Get(certPath).
 					Reply(http.StatusOK).
 					JSON(testCerts)
-				certs, err := api.GetKMIPClientCertificates(ctx, UUID, 100, 0)
+				certs, err := api.GetKMIPClientCertificates(ctx, UUID, 100, 0, true)
 				assert.NoError(t, err)
 				assert.Equal(t, certs.Metadata.NumberOfKeys, testCerts.Metadata.NumberOfKeys)
 				return nil
@@ -5491,7 +5490,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 					Get(objectPath).
 					Reply(http.StatusOK).
 					JSON(testKmipObjects)
-				KmipObjects, err := api.GetKMIPObjects(ctx, UUID, 100, 0)
+				KmipObjects, err := api.GetKMIPObjects(ctx, UUID, 100, 0, false)
 				assert.NoError(t, err)
 				assert.Equal(t, KmipObjects.Metadata.NumberOfKeys, testKmipObjects.Metadata.NumberOfKeys)
 				return nil

--- a/kp_test.go
+++ b/kp_test.go
@@ -5390,7 +5390,12 @@ func TestKMIPMgmtAPI(t *testing.T) {
 			"destroyed_by": "IBMid-0000000001"
 		  }
 		]
-	  }`)
+	}`)
+
+	var limit uint32 = 100
+	var offset uint32 = 0
+	var totalCountTrue bool = true
+	var totalCountFalse bool = false
 
 	baseURL := "http://example.com"
 	adapterPath := "/api/v2/" + KMIPAdapterPath
@@ -5428,7 +5433,12 @@ func TestKMIPMgmtAPI(t *testing.T) {
 					Get(adapterPath).
 					Reply(http.StatusOK).
 					JSON(testAdapters)
-				adapters, err := api.GetKMIPAdapters(ctx, 100, 0, true)
+
+				adapters, err := api.GetKMIPAdapters(ctx, &ListOptions{
+					Limit:      &limit,
+					Offset:     &offset,
+					TotalCount: &totalCountTrue,
+				})
 				assert.NoError(t, err)
 				assert.Equal(t, adapters.Metadata.CollectionTotal, 1)
 				assert.Equal(t, adapters.Metadata.TotalCount, 3)
@@ -5491,9 +5501,14 @@ func TestKMIPMgmtAPI(t *testing.T) {
 				MockAuth()
 				gock.New(baseURL).
 					Get(certPath).
+					MatchParams(map[string]string{"limit": "100", "offset": "0", "totalCount": "false"}).
 					Reply(http.StatusOK).
 					JSON(testCerts)
-				certs, err := api.GetKMIPClientCertificates(ctx, UUID, 100, 0, true)
+				certs, err := api.GetKMIPClientCertificates(ctx, UUID, &ListOptions{
+					Limit:      &limit,
+					Offset:     &offset,
+					TotalCount: &totalCountFalse,
+				})
 				assert.NoError(t, err)
 				assert.Equal(t, certs.Metadata.CollectionTotal, 2)
 				return nil
@@ -5536,9 +5551,16 @@ func TestKMIPMgmtAPI(t *testing.T) {
 				MockAuth()
 				gock.New(baseURL).
 					Get(objectPath).
+					MatchParams(map[string]string{"limit": "0", "totalCount": "true", "state": "1,2"}).
 					Reply(http.StatusOK).
 					JSON(testKmipObjects)
-				KmipObjects, err := api.GetKMIPObjects(ctx, UUID, 100, 0, false)
+				objectLimit := uint32(0)
+				objectFilter := []int{1, 2}
+				KmipObjects, err := api.GetKMIPObjects(ctx, UUID, &ListKmipObjectsOptions{
+					Limit:             &objectLimit,
+					TotalCount:        &totalCountTrue,
+					ObjectStateFilter: &objectFilter,
+				})
 				assert.NoError(t, err)
 				assert.Equal(t, KmipObjects.Metadata.CollectionTotal, 2)
 				return nil

--- a/kp_test.go
+++ b/kp_test.go
@@ -5411,7 +5411,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 				MockAuth()
 				gock.New(baseURL).
 					Delete(adapterPathID).
-					Reply(http.StatusOK)
+					Reply(http.StatusNoContent)
 				err := api.DeleteKMIPAdapter(ctx, UUID)
 				assert.NoError(t, err)
 				return nil
@@ -5475,7 +5475,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 				MockAuth()
 				gock.New(baseURL).
 					Delete(certPath + "/" + UUID).
-					Reply(http.StatusOK)
+					Reply(http.StatusNoContent)
 				err := api.DeleteKMIPClientCertificate(ctx, UUID, UUID)
 				assert.NoError(t, err)
 				return nil
@@ -5519,7 +5519,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 				MockAuth()
 				gock.New(baseURL).
 					Delete(objectPath + "/" + UUID).
-					Reply(http.StatusOK)
+					Reply(http.StatusNoContent)
 				err := api.DeleteKMIPObject(ctx, UUID, UUID)
 				assert.NoError(t, err)
 				return nil

--- a/kp_test.go
+++ b/kp_test.go
@@ -5398,10 +5398,10 @@ func TestKMIPMgmtAPI(t *testing.T) {
 	var totalCountFalse bool = false
 
 	baseURL := "http://example.com"
-	adapterPath := "/api/v2/" + KMIPAdapterPath
+	adapterPath := "/api/v2/" + kmipAdapterPath
 	adapterPathID := adapterPath + "/" + UUID
-	certPath := adapterPathID + "/" + KMIPClientCertSubPath
-	objectPath := adapterPathID + "/" + KMIPObjectSubPath
+	certPath := adapterPathID + "/" + kmipClientCertSubPath
+	objectPath := adapterPathID + "/" + kmipObjectSubPath
 	cases := TestCases{
 		{
 			"KMIP Adapter Create",

--- a/kp_test.go
+++ b/kp_test.go
@@ -5442,7 +5442,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 					Reply(http.StatusOK).
 					JSON(testAdapters)
 
-				adapters, err := api.GetKMIPAdapters(ctx, &ListOptions{
+				adapters, err := api.GetKMIPAdapters(ctx, &ListKmipAdaptersOptions{
 					Limit:      &limit,
 					Offset:     &offset,
 					TotalCount: &totalCountTrue,
@@ -5576,7 +5576,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 					Reply(http.StatusOK).
 					JSON(testKmipObjects)
 				objectLimit := uint32(0)
-				objectFilter := []int{1, 2}
+				objectFilter := []int32{1, 2}
 				kmipObjects, err := api.GetKMIPObjects(ctx, UUID, &ListKmipObjectsOptions{
 					Limit:             &objectLimit,
 					TotalCount:        &totalCountTrue,

--- a/kp_test.go
+++ b/kp_test.go
@@ -5348,10 +5348,10 @@ func TestKMIPMgmtAPI(t *testing.T) {
 	}
 
 	baseURL := "http://example.com"
-	adapterPath := "/api/v2/" + KMIPAdapterPath + "/"
-	adapterPathID := adapterPath + UUID + "/"
-	certPath := adapterPathID + KMIPClientCertSubPath + "/"
-	objectPath := adapterPathID + KMIPObjectSubPath + "/"
+	adapterPath := "/api/v2/" + KMIPAdapterPath
+	adapterPathID := adapterPath + "/" + UUID
+	certPath := adapterPathID + "/" + KMIPClientCertSubPath
+	objectPath := adapterPathID + "/" + KMIPObjectSubPath
 	cases := TestCases{
 		{
 			"KMIP Adapter Create",
@@ -5370,7 +5370,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 				)
 				assert.NoError(t, err)
 				assert.Equal(t, adapter.Name, newAdapter.Name)
-				assert.Equal(t, adapter.CreatedAt, &timestamp)
+				assert.Equal(t, adapter.Description, newAdapter.Description)
 				return nil
 			},
 		},
@@ -5458,7 +5458,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 				defer gock.Off()
 				MockAuth()
 				gock.New(baseURL).
-					Get(certPath + UUID).
+					Get(certPath + "/" + UUID).
 					Reply(http.StatusOK).
 					JSON(singleCert)
 				cert, err := api.GetKMIPClientCertificate(ctx, UUID, UUID)
@@ -5474,7 +5474,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 				defer gock.Off()
 				MockAuth()
 				gock.New(baseURL).
-					Delete(certPath + UUID).
+					Delete(certPath + "/" + UUID).
 					Reply(http.StatusOK)
 				err := api.DeleteKMIPClientCertificate(ctx, UUID, UUID)
 				assert.NoError(t, err)
@@ -5503,7 +5503,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 				defer gock.Off()
 				MockAuth()
 				gock.New(baseURL).
-					Get(objectPath + UUID).
+					Get(objectPath + "/" + UUID).
 					Reply(http.StatusOK).
 					JSON(singleKmipObject)
 				KmipObject, err := api.GetKMIPObject(ctx, UUID, UUID)
@@ -5518,7 +5518,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 				defer gock.Off()
 				MockAuth()
 				gock.New(baseURL).
-					Delete(objectPath + UUID).
+					Delete(objectPath + "/" + UUID).
 					Reply(http.StatusOK)
 				err := api.DeleteKMIPObject(ctx, UUID, UUID)
 				assert.NoError(t, err)

--- a/kp_test.go
+++ b/kp_test.go
@@ -5258,6 +5258,9 @@ func TestKMIPMgmtAPI(t *testing.T) {
 	defer gock.Off()
 	UUID := "feddecaf-0000-0000-0000-1234567890ab"
 	crkUUID := "beddecaf-0000-0000-0000-1234567890ab"
+	adapterName := "kmip-adapter-123"
+	adapterDesc := "our 123rd kmip adapter"
+	certName := "kmip-client-certificate"
 	singleAdapter := []byte(`{
 		"metadata": {
 		  "collectionType": "application/vnd.ibm.kms.kmip-adapter+json",
@@ -5344,7 +5347,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 		"resources": [
 		  {
 			"id": "feddecaf-0000-0000-0000-1234567890ab",
-			"kmip_object_type": "symmetric_key",
+			"kmip_object_type": 2,
 			"state": 3,
 			"created_at": "2000-01-23T04:56:07.000Z",
 			"created_by_kmip_client_cert_id": "reddecaf-0000-0000-0000-1234567890ab",
@@ -5364,7 +5367,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 		"resources": [
 		  {
 			"id": "feddecaf-0000-0000-0000-1234567890ab",
-			"kmip_object_type": "symmetric_key",
+			"kmip_object_type": 2,
 			"state": 3,
 			"created_at": "2000-01-23T04:56:07.000Z",
 			"created_by_kmip_client_cert_id": "reddecaf-0000-0000-0000-1234567890ab",
@@ -5375,7 +5378,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 		  },
 		  {
 			"id": "beddecaf-0000-0000-0000-1234567890ab",
-			"kmip_object_type": "symmetric_key",
+			"kmip_object_type": 2,
 			"state": 5,
 			"created_at": "2000-01-23T04:56:07.000Z",
 			"created_by_kmip_client_cert_id": "reddecaf-0000-0000-0000-1234567890ab",
@@ -5407,12 +5410,12 @@ func TestKMIPMgmtAPI(t *testing.T) {
 				adapter, err := api.CreateKMIPAdapter(
 					ctx,
 					WithNativeProfile(crkUUID),
-					WithKMIPAdapterName(newAdapter.Name),
-					WithKMIPAdapterDescription(newAdapter.Description),
+					WithKMIPAdapterName(adapterName),
+					WithKMIPAdapterDescription(adapterDesc),
 				)
 				assert.NoError(t, err)
-				assert.Equal(t, adapter.Name, newAdapter.Name)
-				assert.Equal(t, adapter.Description, newAdapter.Description)
+				assert.Equal(t, adapter.Name, adapterName)
+				assert.Equal(t, adapter.Description, adapterDesc)
 				return nil
 			},
 		},
@@ -5427,7 +5430,8 @@ func TestKMIPMgmtAPI(t *testing.T) {
 					JSON(testAdapters)
 				adapters, err := api.GetKMIPAdapters(ctx, 100, 0, true)
 				assert.NoError(t, err)
-				assert.Equal(t, adapters.Metadata.CollectionTotal, testAdapters.Metadata.NumberOfKeys)
+				assert.Equal(t, adapters.Metadata.CollectionTotal, 1)
+				assert.Equal(t, adapters.Metadata.TotalCount, 3)
 				return nil
 			},
 		},
@@ -5442,7 +5446,8 @@ func TestKMIPMgmtAPI(t *testing.T) {
 					JSON(singleAdapter)
 				adapter, err := api.GetKMIPAdapter(ctx, UUID)
 				assert.NoError(t, err)
-				assert.Equal(t, adapter.ID, newAdapter.ID)
+				assert.Equal(t, adapter.ID, UUID)
+				assert.Equal(t, adapter.CreatedBy, "IBMid-0000000000")
 				return nil
 			},
 		},
@@ -5472,10 +5477,10 @@ func TestKMIPMgmtAPI(t *testing.T) {
 					ctx,
 					UUID,
 					"dummy_payload",
-					WithKMIPClientCertName(newCertificate.Name),
+					WithKMIPClientCertName(certName),
 				)
 				assert.NoError(t, err)
-				assert.Equal(t, cert.Name, newCertificate.Name)
+				assert.Equal(t, cert.Name, certName)
 				return nil
 			},
 		},
@@ -5490,7 +5495,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 					JSON(testCerts)
 				certs, err := api.GetKMIPClientCertificates(ctx, UUID, 100, 0, true)
 				assert.NoError(t, err)
-				assert.Equal(t, certs.Metadata.CollectionTotal, testCerts.Metadata.NumberOfKeys)
+				assert.Equal(t, certs.Metadata.CollectionTotal, 2)
 				return nil
 			},
 		},
@@ -5505,8 +5510,8 @@ func TestKMIPMgmtAPI(t *testing.T) {
 					JSON(singleCert)
 				cert, err := api.GetKMIPClientCertificate(ctx, UUID, UUID)
 				assert.NoError(t, err)
-				assert.Equal(t, cert.ID, newCertificate.ID)
-				assert.Equal(t, cert.Name, newCertificate.Name)
+				assert.Equal(t, cert.ID, UUID)
+				assert.Equal(t, cert.Name, certName)
 				return nil
 			},
 		},
@@ -5535,7 +5540,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 					JSON(testKmipObjects)
 				KmipObjects, err := api.GetKMIPObjects(ctx, UUID, 100, 0, false)
 				assert.NoError(t, err)
-				assert.Equal(t, KmipObjects.Metadata.CollectionTotal, testKmipObjects.Metadata.NumberOfKeys)
+				assert.Equal(t, KmipObjects.Metadata.CollectionTotal, 2)
 				return nil
 			},
 		},
@@ -5550,7 +5555,8 @@ func TestKMIPMgmtAPI(t *testing.T) {
 					JSON(singleKmipObject)
 				KmipObject, err := api.GetKMIPObject(ctx, UUID, UUID)
 				assert.NoError(t, err)
-				assert.Equal(t, KmipObject.ID, newKmipObject.ID)
+				assert.Equal(t, KmipObject.ID, UUID)
+				assert.Equal(t, KmipObject.KMIPObjectType, 2)
 				return nil
 			},
 		},

--- a/kp_test.go
+++ b/kp_test.go
@@ -5265,8 +5265,8 @@ func TestKMIPMgmtAPI(t *testing.T) {
 		ID:      UUID,
 		Name:    "kmip-adapter-123",
 		Profile: kmipAdapterProfile,
-		ProfileData: KMIPProfileNative{
-			CrkID: crkUUID,
+		ProfileData: map[string]string{
+			"crk_id": crkUUID,
 		},
 		Description: "our 123rd kmip adapter",
 		CreatedAt:   &timestamp,


### PR DESCRIPTION
Add CRD (where applicable, KMIP objects do not have a create) endpoints for KMIP adapters, certificates and objects.