### PR TITLE
Add force delete option for KMIP object

### DIFF
--- a/key_rings.go
+++ b/key_rings.go
@@ -59,9 +59,9 @@ func (c *Client) GetKeyRings(ctx context.Context) (*KeyRings, error) {
 	return &rings, nil
 }
 
-type DeleteKeyRingQueryOption func(*http.Request)
+type RequestOpt func(*http.Request)
 
-func WithForce(force bool) DeleteKeyRingQueryOption {
+func WithForce(force bool) RequestOpt {
 	return func(req *http.Request) {
 		query := req.URL.Query()
 		query.Add("force", strconv.FormatBool(force))
@@ -72,7 +72,7 @@ func WithForce(force bool) DeleteKeyRingQueryOption {
 // DeleteRing method deletes the key ring with the provided name in the instance
 // For information please refer to the link below:
 // https://cloud.ibm.com/docs/key-protect?topic=key-protect-managing-key-rings#delete-key-ring-api
-func (c *Client) DeleteKeyRing(ctx context.Context, id string, opts ...DeleteKeyRingQueryOption) error {
+func (c *Client) DeleteKeyRing(ctx context.Context, id string, opts ...RequestOpt) error {
 	req, err := c.newRequest("DELETE", fmt.Sprintf(keyRingPath+"/%s", id), nil)
 	for _, opt := range opts {
 		opt(req)

--- a/kmip_mgmt_objects.go
+++ b/kmip_mgmt_objects.go
@@ -92,11 +92,15 @@ func (c *Client) GetKMIPObject(ctx context.Context, adapter_id, object_id string
 	return unwrapKMIPObject(objects), nil
 }
 
-func (c *Client) DeleteKMIPObject(ctx context.Context, adapter_id, object_id string) error {
+func (c *Client) DeleteKMIPObject(ctx context.Context, adapter_id, object_id string, opts ...RequestOpt) error {
 	req, err := c.newRequest("DELETE", fmt.Sprintf("%s/%s/%s/%s",
 		kmipAdapterPath, adapter_id, kmipObjectSubPath, object_id), nil)
 	if err != nil {
 		return err
+	}
+
+	for _, opt := range opts {
+		opt(req)
 	}
 
 	_, err = c.do(ctx, req, nil)

--- a/kp_test.go
+++ b/kp_test.go
@@ -5623,7 +5623,7 @@ func TestKMIPMgmtAPI(t *testing.T) {
 				gock.New(baseURL).
 					Delete(objectPath + "/" + UUID).
 					Reply(http.StatusNoContent)
-				err := api.DeleteKMIPObject(ctx, UUID, UUID)
+				err := api.DeleteKMIPObject(ctx, UUID, UUID, WithForce(false))
 				assert.NoError(t, err)
 				return nil
 			},


### PR DESCRIPTION
Adding new option parameter to `DeleteKMIPObject()` to allow for the force deletion of a KMIP object which will allow deletion regardless of any blocking conditions.

The new option parameter reuses what used to be `DeleteKeyRingQueryOption`, which is renamed to `RequestOpt`, to avoid duplicate code.