### PR TITLE
Delete renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "postUpdateOptions": ["gomodTidy"]
-}


### PR DESCRIPTION
In order to avoid confusion, this PR removes renovate.json because the project's dependency and security scanning requirements are already covered by Dependabot and CodeQL.